### PR TITLE
Support user and client credentials grant types

### DIFF
--- a/data/access_token.go
+++ b/data/access_token.go
@@ -22,7 +22,7 @@ type AccessToken struct {
 	Scope       util.StringSet
 	Expires     time.Time
 	ClientUUID  string
-	AccountUUID string
+	AccountUUID sql.NullString
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }

--- a/data/grant_request.go
+++ b/data/grant_request.go
@@ -101,7 +101,7 @@ func (req *GrantRequest) ExchangeCodeForTokens() (string, string, error) {
 		Scope:       req.ScopeRequested,
 		Expires:     time.Now().Add(conf.GetServerConfig().GrantReqLifeTime),
 		ClientUUID:  req.ClientUUID,
-		AccountUUID: req.AccountUUID.String}
+		AccountUUID: req.AccountUUID}
 
 	tx := database.MustBegin()
 	err := tx.Get(refresh, qCreateRefresh, refresh.Token, refresh.Scope, refresh.ClientUUID, refresh.AccountUUID)

--- a/data/grant_request_test.go
+++ b/data/grant_request_test.go
@@ -98,7 +98,7 @@ func TestGrantRequest_ExchangeCodeForTokens(t *testing.T) {
 	if !ok {
 		t.Error("Unable to find created access token")
 	}
-	if access.AccountUUID != uuidAlice {
+	if !access.AccountUUID.Valid || access.AccountUUID.String != uuidAlice {
 		t.Error("Access token has a wrong account UUID")
 	}
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,13 +1,15 @@
 GIN-Auth API
 ============
 
-### Authenticate: grant type code
 
 
-#### 1. Request access
+Authenticate: grant type code
+-----------------------------
 
-The client should redirect the browser (302 moved temporarily) to the following URL
-with the parameters listed below.
+### 1. Request access
+
+The client should redirect the browser (302) to the following URL with the parameters listed below encoded
+in the query string.
 
 ##### URL
 
@@ -15,34 +17,38 @@ with the parameters listed below.
 GET https://<host>/oauth/authorize
 ```
 
-##### Parameters
+##### Query Parameters
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
 | response_type | string  | Must be set to `code` |
 | client_id     | string  | The ID of a registered client |
 | redirect_uri  | string  | URL to redirect to after authorization |
-| scope         | string  | Comma separated list of scopes |
+| scope         | string  | Space separated list of scopes |
 | state         | string  | Random string to protect against CSRF |
 
-##### Errors (not redirected)
+##### Errors
 
 Show an error page if:
 
 * The client ID is unknown
 * The redirect URL does not match exactly one registered URL for the client
 * The redirect URL does not use https
-* One of the given scopes is not registered
+* One of the given scopes is not registered or blacklisted
 
 ##### Response
 
-Redirect the browser (302 moved temporarily) to the [login page](#login-page) using a newly generated request id.
+Redirect the browser (302) to a page which performs an appropriate authentication and approval process.
+If the authentication and approval was successful the response is a redirect (302) to the requested
+`redirect_uri` containing the parameters `code`, `scope` and `state` as query parameters.
 
-#### 2. Exchange token
+In the next step the `code` can be exchanged for an access and refresh token.
 
-If the authentication and approval was successful the response is a redirect (302) to the requested `redirect_uri`
-containing the parameters `code`, `scope` and `state`.
-In the next step the access code can be used to obtain an access token.
+### 2. Exchange an access code for a token
+
+To exchange a previously issued code for an access token.
+The client must provide its `client_id` and `client_secret` either with the `Authorization` header or encoded in
+the request body.
 
 ##### URL
 
@@ -50,28 +56,35 @@ In the next step the access code can be used to obtain an access token.
 POST https://<host>/oauth/token
 ```
 
-##### Basic authorization header
+##### Authorization Header
 
-Send `client_id` and `client_secret` as HTTP basic authorization header.
+Send `client_id` and `client_secret` as HTTP basic authorization header (optional).
 
-##### Parameters (application/x-www-form-urlencoded)
+##### Request Body (application/x-www-form-urlencoded)
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
 | code          | string  | The code obtained in step 1 |
-| redirect_uri  | string  | URL to redirect to after authorization |
 | grant_type    | string  | Must be 'authorization_code' |
+| client_id     | string  | The client id (optional if the authorization header is present) |
+| client_secret | string  | The client secret (optional if the authorization header is present) |
 
 ##### Errors
 
-Errors are returned encoded as json with the following format:
+Return an error if:
 
-```javascript
+* The client ID is unknown
+* The client secret does not match
+* The code is not valid
+
+Errors are returned encoded as JSON using the following format:
+
+```json
 {
   "code": 400,
   "error": "Bad Request",
   "message": "Unable to set one or more fields",
-  "reasons": { // reasons may be null
+  "reasons": {
     "grant_type": "Field grant type was missing"
   }
 }
@@ -79,14 +92,72 @@ Errors are returned encoded as json with the following format:
 
 ##### Response
 
-If successful the response body contains the parameters `access_token`, `refresh_token` and `token_type` as JSON.
+If successful the response body contains the `scope`, `access_token`, `refresh_token` and `token_type`
+as JSON.
 
-TODO should we also support other encodings (application/x-www-form-urlencoded) depending on the Accept header
-of the request?
+```json
+{
+  "scope": "scope1 scope2",
+  "access_token": "...",
+  "refresh_token": "...",
+  "token_type": "Bearer"
+}
+```
 
-### Authenticate: grant type implicit
+*TODO: should we also support other encodings (application/x-www-form-urlencoded) depending on the Accept header
+of the request?*
 
-#### Request implicit access token
+### 3. Exchange a refresh token for an access token
+
+To exchange a previously issued refresh token for an access token, the client must provide its `client_id` and `client_secret`
+either with the `Authorization` header or encoded in the request body.
+
+##### URL
+
+```
+POST https://<host>/oauth/token
+```
+
+##### Authorization Header
+
+Send `client_id` and `client_secret` as HTTP basic authorization header (optional).
+
+##### Request Body (application/x-www-form-urlencoded)
+
+| Name          | Type    | Description |
+| ------------- | ------- | ---- |
+| grant_type    | string  | Must be 'refresh_token' |
+| refresh_token | string  | The refresh token |
+| client_id     | string  | The client id (optional if the authorization header is present) |
+| client_secret | string  | The client secret (optional if the authorization header is present) |
+
+##### Errors
+
+Return an error if:
+
+* The client ID is unknown
+* The client secret does not match
+* The refresh token is not valid for the client
+
+Errors are returned encoded as JSON in the [above shown format](#errors-1).
+
+##### Response
+
+If successful the response body contains the parameters `scope`, `access_token` and `token_type` as JSON.
+
+```json
+{
+  "scope": "scope1 scope2",
+  "access_token": "...",
+  "refresh_token": "...",
+  "token_type": "Bearer"
+}
+```
+
+
+
+Authenticate: grant type implicit
+---------------------------------
 
 ##### URL
 
@@ -94,14 +165,14 @@ of the request?
 GET https://<host>/oauth/authorize
 ```
 
-##### Parameters
+##### Query Parameters
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
 | response_type | string  | Must be set to `token` |
 | client_id     | string  | The ID of a registered client |
 | redirect_uri  | string  | URL to redirect to after authorization |
-| scope         | string  | Comma separated list of scopes |
+| scope         | string  | Space separated list of scopes |
 | state         | string  | Random string to protect against CSRF |
 
 ##### Errors (not redirected)
@@ -115,16 +186,21 @@ Show an error page if:
 
 ##### Response
 
-Redirect the browser (302 moved temporarily) to the [login page](#login-page) using a newly generated request id.
+Redirect the browser (302) to a page which performs an appropriate authentication and approval process.
 
 If the authentication and approval was successful the response is a redirect (302) to the requested `redirect_uri`
 containing the parameters `access_token`, `token_type`, `scope` and `state`.
 
-### Authenticate: grant type owner credentials
 
-Non web applications can obtain a token by just using http basic auth.
 
-#### Request access token directly
+Authenticate: grant type owner credentials
+------------------------------------------
+
+Non web applications can obtain a token with the resource owners credentials.
+To get an access token, the client must provide its `client_id` and `client_secret` either with the
+`Authorization` header or encoded in the request body.
+
+### Request access token directly
 
 ##### URL
 
@@ -134,22 +210,98 @@ POST https://<host>/oauth/token
 
 ##### Headers
 
-| Name           | Value |
-| -------------- | --- |
-| Authorization  | Basic <username:password> |
-| X-OAuth-Scopes | <list-of-scopes> |
+Send `client_id` and `client_secret` as HTTP basic authorization header (optional).
 
-##### Error
+##### Request Body (application/x-www-form-urlencoded)
 
-TODO
+| Name          | Type    | Description |
+| ------------- | ------- | ---- |
+| scope         | string  | Space separated list of scopes |
+| username      | string  | The resource owners login name |
+| password      | string  | The resource owners password |
+| grant_type    | string  | Must be 'password' |
+| client_id     | string  | The client id (optional if the authorization header is present) |
+| client_secret | string  | The client secret (optional if the authorization header is present) |
+
+##### Errors
+
+Return an error if:
+
+* The client ID is unknown
+* The client secret does not match
+* The user credentials are not valid
+* The requested scope is not whitelisted
+
+Errors are returned encoded as JSON in the [above shown format](#errors-1).
 
 ##### Response
 
-If successful the response body contains the parameters `access_token` and `token_type` as application/x-www-form-urlencoded.
+If successful the response body contains the parameters `scope`, `access_token` and `token_type` as JSON.
 
-TODO should we also support other encodings (application/json) depending on the Accept header of the request?
+```json
+{
+  "scope": "scope1 scope2",
+  "access_token": "...",
+  "token_type": "Bearer"
+}
+```
 
-### Login page
+
+
+Authenticate: grant type client credentials
+-------------------------------------------
+
+Clients can request an access token with limited privileges / scope directly with their client id and secret.
+To get an access token, the client must provide its `client_id` and `client_secret` either with the
+`Authorization` header or encoded in the request body.
+
+### Request access token directly
+
+##### URL
+
+```
+POST https://<host>/oauth/token
+```
+
+##### Headers
+
+Send `client_id` and `client_secret` as HTTP basic authorization header (optional).
+
+##### Request Body (application/x-www-form-urlencoded)
+
+| Name          | Type    | Description |
+| ------------- | ------- | ---- |
+| scope         | string  | Space separated list of scopes |
+| grant_type    | string  | Must be 'client_credentials' |
+| client_id     | string  | The client id (optional if the authorization header is present) |
+| client_secret | string  | The client secret (optional if the authorization header is present) |
+
+##### Errors
+
+Return an error if:
+
+* The client ID is unknown
+* The client secret does not match
+* The requested scope is not whitelisted
+
+Errors are returned encoded as JSON in the [above shown format](#errors-1).
+
+##### Response
+
+If successful the response body contains the parameters `scope`, `access_token` and `token_type` as JSON.
+
+```json
+{
+  "scope": "scope1 scope2",
+  "access_token": "...",
+  "token_type": "Bearer"
+}
+```
+
+
+
+Login page
+----------
 
 A login page shown during a `code` or `implicit` authorization request.
 
@@ -159,7 +311,7 @@ A login page shown during a `code` or `implicit` authorization request.
 GET https://<host>/oauth/login_page
 ```
 
-##### Parameters
+##### Query Parameters
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
@@ -180,7 +332,10 @@ Show an error page if the the `request_id` does not belong to a registered reque
 If a valid `session` cookie is present the browser is redirected (302 moved temporarily) to the [approve page](#approve-page).
 If the browser did not send a valid session the login form is shown and submitted to [login](#login)
 
-### Login
+
+
+Login
+-----
 
 Checks the login credentials and the `request_id`
 
@@ -190,7 +345,7 @@ Checks the login credentials and the `request_id`
 POST https://<host>/oauth/login
 ```
 
-##### Parameters (application/x-www-form-urlencoded)
+##### Request Body (application/x-www-form-urlencoded)
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
@@ -216,7 +371,10 @@ In case of an implicit grant request the redirect uri contains the parameters `a
 If the user has not approved one of the requested scopes for this client before the browser is redirected to
 the [approve page](#approve-page).
 
-### Approve page
+
+
+Approve page
+------------
 
 Shows the resource owner a page that allows him to approve certain scopes for a specific client.
 
@@ -226,7 +384,7 @@ Shows the resource owner a page that allows him to approve certain scopes for a 
 GET https://<host>/oauth/approve_page
 ```
 
-##### Parameters
+##### Query Parameters
 
 | Name          | Type    | Description |
 | ------------- | ------- | ---- |
@@ -249,13 +407,18 @@ Redirect the user to the login form if the `session` is not valid.
 
 Submit configured scopes to [approve](#approve-scopes)
 
-### Approve scopes
+
+
+Approve scopes
+--------------
+
+##### URL
 
 ```
 POST https://<host>/oauth/approve
 ```
 
-##### Parameters (application/x-www-form-urlencoded)
+##### Request Body (application/x-www-form-urlencoded)
 
 | Name           | Type    | Description |
 | -------------- | ------- | ---- |
@@ -285,7 +448,10 @@ In case of success the browser is redirected to the `redirect_uri` associated wi
 If the grant request type was code the redirect URL contains the parameters `code`, `scope` and `state`.
 In case of an implicit grant request the redirect uri contains the parameters `access_token` and `token_type`.
 
-### Validate tokens
+
+
+Validate tokens
+---------------
 
 Validates an access token and provides information about the token such as expiration date and scope.
 
@@ -309,30 +475,34 @@ Returns information about the token encoded as JSON.
   "jti": "<token>",     // token identifier
   "exp": 1300819380,    // expiration time
   "iss": "gin-auth",
-  "login": "...",       // login of the account
+  "login": "...",       // login of the account (null if not not accociated with an account)
+  "account_url": "..."  // url to the the account (null if not not accociated with an account)
   "scope": ["s1", "s2"] // the scope which may be accessed with the token
 }
 ```
 
-### Account API
 
-#### Error handling
+
+Account API
+-----------
+
+### Error handling
 
 In case of errors calls to the account API result in a response with the respective HTTP status code.
 The body contains further information formatted as JSON:
 
-```javascript
+```json
 {
   "code": 400,
   "error": "Bad Request",
   "message": "...",
-  "reasons": { // reasons may be null
+  "reasons": {
     "foo": "Field foo was missing"
   }
 }
 ```
 
-#### List all accounts
+### List all accounts
 
 ##### URL
 
@@ -365,7 +535,7 @@ Returns a list of all accounts as JSON:
 ]
 ```
 
-#### Get an account
+### Get an account
 
 ##### URL
 
@@ -396,7 +566,7 @@ Returns an account object as JSON:
 }
 ```
 
-#### Update an account
+### Update an account
 
 ##### URL
 
@@ -427,7 +597,7 @@ Additional attributes may be present, but will be ignored.
 
 The changed account object as JSON (see above).
 
-#### Update account password
+### Update account password
 
 ##### URL
 
@@ -454,9 +624,12 @@ The token scope must contain 'account-write' to change the own password.
 
 If the password was successfully changed the status code is 200 and the response body is empty.
 
-### SSH-key API
 
-#### List keys per user
+
+SSH-key API
+-----------
+
+### List keys per user
 
 ##### URL
 
@@ -488,7 +661,7 @@ Returns a list of ssh key objects as JSON:
 ]
 ```
 
-#### Get ssh key
+### Get ssh key
 
 ##### URL
 
@@ -518,7 +691,7 @@ Returns an ssh key object as JSON:
 }
 ```
 
-#### Remove ssh key
+### Remove ssh key
 
 ##### URL
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -472,12 +472,12 @@ Returns information about the token encoded as JSON.
 ```javascript
 {
   "url": "https://<host>/oauth/validate/<token>",
-  "jti": "<token>",     // token identifier
-  "exp": 1300819380,    // expiration time
+  "jti": "<token>",        // token identifier
+  "exp": 1300819380,       // expiration time
   "iss": "gin-auth",
-  "login": "...",       // login of the account (null if not not accociated with an account)
-  "account_url": "..."  // url to the the account (null if not not accociated with an account)
-  "scope": ["s1", "s2"] // the scope which may be accessed with the token
+  "login": "...",          // login of the account (null if not not accociated with an account)
+  "account_url": "...",    // url to the the account (null if not not accociated with an account)
+  "scope": "scope1 scope2" // space separated list of scopes
 }
 ```
 

--- a/resources/conf/clients.yml
+++ b/resources/conf/clients.yml
@@ -16,3 +16,8 @@
     - account-admin
   RedirectURIs:
     - https://localhost:8081/login
+- UUID: 5b2ca112-0ecc-41ff-8315-221024345ab8
+  Name: gin-shell
+  Secret: secret
+  ScopeWhitelist:
+    - account-admin

--- a/resources/conf/migrations/1_initial-schema.sql
+++ b/resources/conf/migrations/1_initial-schema.sql
@@ -87,7 +87,7 @@ CREATE TABLE AccessTokens (
   scope             VARCHAR[] NOT NULL ,
   expires           TIMESTAMP NOT NULL ,
   clientUUID        VARCHAR(36) NOT NULL REFERENCES Clients(uuid) ON DELETE CASCADE ,
-  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) REFERENCES Accounts(uuid) ON DELETE CASCADE ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );

--- a/web/account.go
+++ b/web/account.go
@@ -50,7 +50,7 @@ func GetAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != account.UUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
+	if oauth.Token.AccountUUID.String != account.UUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
 		PrintErrorJSON(w, r, "Access to requested account forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -76,7 +76,7 @@ func UpdateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != account.UUID || !oauth.Match.Contains("account-write") && !oauth.Match.Contains("account-admin") {
+	if oauth.Token.AccountUUID.String != account.UUID || !oauth.Match.Contains("account-write") && !oauth.Match.Contains("account-admin") {
 		PrintErrorJSON(w, r, "Access to requested account forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -115,7 +115,7 @@ func UpdateAccountPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != account.UUID || !oauth.Match.Contains("account-write") {
+	if oauth.Token.AccountUUID.String != account.UUID || !oauth.Match.Contains("account-write") {
 		PrintErrorJSON(w, r, "Access to requested account forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -176,7 +176,7 @@ func ListAccountKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != account.UUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
+	if oauth.Token.AccountUUID.String != account.UUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
 		PrintErrorJSON(w, r, "Access to requested key forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -207,7 +207,7 @@ func GetKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != key.AccountUUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
+	if oauth.Token.AccountUUID.String != key.AccountUUID || !oauth.Match.Contains("account-read") && !oauth.Match.Contains("account-admin") {
 		PrintErrorJSON(w, r, "Access to requested key forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -235,7 +235,7 @@ func CreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != account.UUID || !oauth.Match.Contains("account-write") {
+	if oauth.Token.AccountUUID.String != account.UUID || !oauth.Match.Contains("account-write") {
 		PrintErrorJSON(w, r, "Access to requested account forbidden", http.StatusUnauthorized)
 		return
 	}
@@ -274,7 +274,7 @@ func DeleteKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oauth.Token.AccountUUID != key.AccountUUID || !oauth.Match.Contains("account-write") {
+	if oauth.Token.AccountUUID.String != key.AccountUUID || !oauth.Match.Contains("account-write") {
 		PrintErrorJSON(w, r, "Access to requested account forbidden", http.StatusUnauthorized)
 		return
 	}

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -94,18 +94,18 @@ func TestOAuthHandler(t *testing.T) {
 	}
 }
 
-func newAuthQuery() url.Values {
-	query := url.Values{}
-	query.Add("response_type", "code")
-	query.Add("client_id", "gin")
-	query.Add("redirect_uri", "https://localhost:8081/login")
-	query.Add("scope", "repo-read repo-write")
-	query.Add("state", "testcode")
-	return query
-}
-
 func TestAuthorize(t *testing.T) {
 	handler := InitTestHttpHandler(t)
+
+	mkQuery := func() url.Values {
+		query := url.Values{}
+		query.Add("response_type", "code")
+		query.Add("client_id", "gin")
+		query.Add("redirect_uri", "https://localhost:8081/login")
+		query.Add("scope", "repo-read repo-write")
+		query.Add("state", "testcode")
+		return query
+	}
 
 	// missing query param
 	request, _ := http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
@@ -116,7 +116,7 @@ func TestAuthorize(t *testing.T) {
 	}
 
 	// wrong response type
-	query := newAuthQuery()
+	query := mkQuery()
 	query.Set("response_type", "wrong")
 	request, _ = http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
 	request.URL.RawQuery = query.Encode()
@@ -127,7 +127,7 @@ func TestAuthorize(t *testing.T) {
 	}
 
 	// wrong scope
-	query = newAuthQuery()
+	query = mkQuery()
 	query.Set("scope", "foo,bar")
 	request, _ = http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
 	request.URL.RawQuery = query.Encode()
@@ -138,7 +138,7 @@ func TestAuthorize(t *testing.T) {
 	}
 
 	// wrong client id
-	query = newAuthQuery()
+	query = mkQuery()
 	query.Set("client_id", "doesnotexist")
 	request, _ = http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
 	request.URL.RawQuery = query.Encode()
@@ -149,7 +149,7 @@ func TestAuthorize(t *testing.T) {
 	}
 
 	// wrong redirect
-	query = newAuthQuery()
+	query = mkQuery()
 	query.Set("redirect_uri", "https://example.com/invalid")
 	request, _ = http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
 	request.URL.RawQuery = query.Encode()
@@ -161,7 +161,7 @@ func TestAuthorize(t *testing.T) {
 
 	// all OK
 	request, _ = http.NewRequest("GET", "/oauth/authorize", strings.NewReader(""))
-	request.URL.RawQuery = newAuthQuery().Encode()
+	request.URL.RawQuery = mkQuery().Encode()
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusFound {
@@ -207,16 +207,16 @@ func TestLoginPage(t *testing.T) {
 	}
 }
 
-func newLoginBody() *url.Values {
-	body := &url.Values{}
-	body.Add("request_id", "U7JIKKYI")
-	body.Add("login", "bob")
-	body.Add("password", "testtest")
-	return body
-}
-
 func TestLogin(t *testing.T) {
 	handler := InitTestHttpHandler(t)
+
+	mkBody := func() *url.Values {
+		body := &url.Values{}
+		body.Add("request_id", "U7JIKKYI")
+		body.Add("login", "bob")
+		body.Add("password", "testtest")
+		return body
+	}
 
 	// form param missing
 	request, _ := http.NewRequest("POST", "/oauth/login", strings.NewReader(""))
@@ -228,7 +228,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	// wrong request id
-	body := newLoginBody()
+	body := mkBody()
 	body.Set("request_id", "doesnotexist")
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -239,7 +239,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	// wrong login
-	body = newLoginBody()
+	body = mkBody()
 	body.Set("login", "doesnotexist")
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -250,7 +250,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	// wrong password
-	body = newLoginBody()
+	body = mkBody()
 	body.Set("password", "notapassword")
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -261,7 +261,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	// all OK
-	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(newLoginBody().Encode()))
+	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(mkBody().Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
@@ -308,19 +308,19 @@ func TestApprovePage(t *testing.T) {
 	}
 }
 
-func newApproveBody() *url.Values {
-	body := &url.Values{}
-	body.Add("request_id", "B4LIMIMB")
-	body.Add("scope", "repo-read")
-	body.Add("scope", "repo-write")
-	return body
-}
-
 func TestApprove(t *testing.T) {
 	handler := InitTestHttpHandler(t)
 
+	mkBody := func() *url.Values {
+		body := &url.Values{}
+		body.Add("request_id", "B4LIMIMB")
+		body.Add("scope", "repo-read")
+		body.Add("scope", "repo-write")
+		return body
+	}
+
 	// wrong request id
-	body := newApproveBody()
+	body := mkBody()
 	body.Set("request_id", "doesnotexist")
 	request, _ := http.NewRequest("POST", "/oauth/approve", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -331,7 +331,7 @@ func TestApprove(t *testing.T) {
 	}
 
 	// all OK
-	request, _ = http.NewRequest("POST", "/oauth/approve", strings.NewReader(newApproveBody().Encode()))
+	request, _ = http.NewRequest("POST", "/oauth/approve", strings.NewReader(mkBody().Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
@@ -347,20 +347,20 @@ func TestApprove(t *testing.T) {
 	}
 }
 
-func newCodeTokenBody(code string) *url.Values {
-	body := &url.Values{}
-	body.Add("code", code)
-	body.Add("grant_type", "authorization_code")
-	return body
-}
-
 func TestTokenAuthorizationCode(t *testing.T) {
 	const codeAlice = "HGZQP6WE"
+
+	mkBody := func(code string) *url.Values {
+		body := &url.Values{}
+		body.Add("code", code)
+		body.Add("grant_type", "authorization_code")
+		return body
+	}
 
 	handler := InitTestHttpHandler(t)
 
 	// wrong client id
-	body := newCodeTokenBody(codeAlice)
+	body := mkBody(codeAlice)
 	request, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("doesnotexist", "secret")
@@ -371,7 +371,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	}
 
 	// wrong client secret
-	body = newCodeTokenBody(codeAlice)
+	body = mkBody(codeAlice)
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "wrongsecret")
@@ -382,7 +382,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	}
 
 	// wrong code
-	body = newCodeTokenBody("reallywrongcode")
+	body = mkBody("reallywrongcode")
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "secret")
@@ -393,7 +393,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	}
 
 	// all OK (with authorization header)
-	body = newCodeTokenBody(codeAlice)
+	body = mkBody(codeAlice)
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "secret")
@@ -417,7 +417,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	}
 
 	// try to read the same code again
-	body = newCodeTokenBody(codeAlice)
+	body = mkBody(codeAlice)
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "secret")
@@ -430,7 +430,7 @@ func TestTokenAuthorizationCode(t *testing.T) {
 
 	// all OK (with client credentials in body)
 	data.InitTestDb(t)
-	body = newCodeTokenBody(codeAlice)
+	body = mkBody(codeAlice)
 	body.Add("client_id", "gin")
 	body.Add("client_secret", "secret")
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
@@ -455,20 +455,20 @@ func TestTokenAuthorizationCode(t *testing.T) {
 	}
 }
 
-func newRefreshTokenBody(refreshToken string) *url.Values {
-	body := &url.Values{}
-	body.Add("refresh_token", refreshToken)
-	body.Add("grant_type", "refresh_token")
-	return body
-}
-
 func TestTokenRefreshToken(t *testing.T) {
 	const refreshTokenAlice = "YYPTDSVZ"
+
+	mkBody := func(refreshToken string) *url.Values {
+		body := &url.Values{}
+		body.Add("refresh_token", refreshToken)
+		body.Add("grant_type", "refresh_token")
+		return body
+	}
 
 	handler := InitTestHttpHandler(t)
 
 	// wrong client id
-	body := newRefreshTokenBody(refreshTokenAlice)
+	body := mkBody(refreshTokenAlice)
 	request, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("doesnotexist", "secret")
@@ -479,7 +479,7 @@ func TestTokenRefreshToken(t *testing.T) {
 	}
 
 	// wrong client secret
-	body = newRefreshTokenBody(refreshTokenAlice)
+	body = mkBody(refreshTokenAlice)
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "wrongsecret")
@@ -490,7 +490,7 @@ func TestTokenRefreshToken(t *testing.T) {
 	}
 
 	// wrong refresh token
-	body = newRefreshTokenBody("wrongtoken")
+	body = mkBody("wrongtoken")
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "secret")
@@ -501,7 +501,7 @@ func TestTokenRefreshToken(t *testing.T) {
 	}
 
 	// all OK (with authorization header)
-	body = newRefreshTokenBody(refreshTokenAlice)
+	body = mkBody(refreshTokenAlice)
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.SetBasicAuth("gin", "secret")
@@ -522,7 +522,7 @@ func TestTokenRefreshToken(t *testing.T) {
 	}
 
 	// all OK (with client credentials in body)
-	body = newRefreshTokenBody(refreshTokenAlice)
+	body = mkBody(refreshTokenAlice)
 	body.Add("client_id", "gin")
 	body.Add("client_secret", "secret")
 	request, _ = http.NewRequest("POST", "/oauth/token", strings.NewReader(body.Encode()))

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -98,7 +98,7 @@ func newAuthQuery() url.Values {
 	query.Add("response_type", "code")
 	query.Add("client_id", "gin")
 	query.Add("redirect_uri", "https://localhost:8081/login")
-	query.Add("scope", "repo-read,repo-write")
+	query.Add("scope", "repo-read repo-write")
 	query.Add("state", "testcode")
 	return query
 }


### PR DESCRIPTION
- Refresh tokens can be exchanged for access tokens
- Retrieve access token with user credentials
- Retrieve access token with client credentials
- Updated API documentation
