### PR TITLE
Account activation

### DIFF
--- a/resources/templates/activation.html
+++ b/resources/templates/activation.html
@@ -1,6 +1,6 @@
 {{ define "content" }}
 
 <h1>Account activation</h1>
-<div>Congratulation! The account for {{ .Login }} has been activated and can now be used.</div>
+<div>Congratulation {{ .FirstName }} {{ .LastName }}! The account for {{ .Login }} has been activated and can now be used.</div>
 
 {{ end }}

--- a/resources/templates/activation.html
+++ b/resources/templates/activation.html
@@ -1,0 +1,6 @@
+{{ define "content" }}
+
+<h1>Account activation</h1>
+<div>Congratulation! The account for {{ .Login }} has been activated and can now be used.</div>
+
+{{ end }}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -819,9 +819,18 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, exists := data.GetAccountByActivationCode(getCode)
+	account, exists := data.GetAccountByActivationCode(getCode)
 	if !exists {
 		PrintErrorHTML(w, r, "Requested account does not exist", http.StatusBadRequest)
 		return
+	}
+
+	tmpl := conf.MakeTemplate("activation.html")
+	w.Header().Add("Cache-Control", "no-store")
+	w.Header().Add("Content-Type", "text/html")
+
+	err = tmpl.ExecuteTemplate(w, "layout", account)
+	if err != nil {
+		panic(err)
 	}
 }

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -805,3 +805,17 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 }
+
+// Activation removes an existing activation code from an account, thus rendering the account active.
+func Activation(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		panic(err)
+	}
+
+	getCode := r.Form.Get("activation_code")
+	if getCode == "" {
+		PrintErrorHTML(w, r, "Account activation code was absent", http.StatusBadRequest)
+		return
+	}
+}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -825,6 +825,12 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	account.ActivationCode.Valid = false
+	err = account.Update()
+	if err != nil {
+		PrintErrorHTML(w, r, "An error during activation", http.StatusInternalServerError)
+	}
+
 	tmpl := conf.MakeTemplate("activation.html")
 	w.Header().Add("Cache-Control", "no-store")
 	w.Header().Add("Content-Type", "text/html")

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -810,7 +810,8 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 func Activation(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
-		panic(err)
+		PrintErrorHTML(w, r, "Activation request was malformed", http.StatusBadRequest)
+		return
 	}
 
 	getCode := r.Form.Get("activation_code")
@@ -828,7 +829,8 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 	account.ActivationCode.Valid = false
 	err = account.Update()
 	if err != nil {
-		PrintErrorHTML(w, r, "An error during activation", http.StatusInternalServerError)
+		PrintErrorHTML(w, r, "An error occured during activation", http.StatusInternalServerError)
+		return
 	}
 
 	tmpl := conf.MakeTemplate("activation.html")

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -822,15 +822,14 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 
 	account, exists := data.GetAccountByActivationCode(getCode)
 	if !exists {
-		PrintErrorHTML(w, r, "Requested account does not exist", http.StatusBadRequest)
+		PrintErrorHTML(w, r, "Requested account does not exist", http.StatusNotFound)
 		return
 	}
 
 	account.ActivationCode.Valid = false
 	err = account.Update()
 	if err != nil {
-		PrintErrorHTML(w, r, "An error occured during activation", http.StatusInternalServerError)
-		return
+		panic(err)
 	}
 
 	tmpl := conf.MakeTemplate("activation.html")

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -818,4 +818,10 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		PrintErrorHTML(w, r, "Account activation code was absent", http.StatusBadRequest)
 		return
 	}
+
+	_, exists := data.GetAccountByActivationCode(getCode)
+	if !exists {
+		PrintErrorHTML(w, r, "Requested account does not exist", http.StatusBadRequest)
+		return
+	}
 }

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -948,7 +948,7 @@ func TestActivation(t *testing.T) {
 
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
-	if response.Code != http.StatusBadRequest {
+	if response.Code != http.StatusNotFound {
 		t.Errorf("Expected StatusBadRequest on invalid activationCode but got '%d'", response.Code)
 	}
 
@@ -960,7 +960,7 @@ func TestActivation(t *testing.T) {
 
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
-	if response.Code != http.StatusBadRequest {
+	if response.Code != http.StatusNotFound {
 		t.Errorf("Expected StatusBadRequest on disabled account but got '%d'", response.Code)
 	}
 

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -947,4 +947,15 @@ func TestActivation(t *testing.T) {
 	if response.Code != http.StatusBadRequest {
 		t.Errorf("Expected StatusBadRequest on invalid activationCode but got '%d'", response.Code)
 	}
+
+	request, _ = http.NewRequest("GET", activationURL, strings.NewReader(""))
+	q = request.URL.Query()
+	q.Add("activation_code", "ac_a")
+	request.URL.RawQuery = q.Encode()
+
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid activationCode but got '%d'", response.Code)
+	}
 }

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -936,4 +936,15 @@ func TestActivation(t *testing.T) {
 	if response.Code != http.StatusBadRequest {
 		t.Errorf("Expected StatusBadRequest on empty activationCode but got '%d'", response.Code)
 	}
+
+	request, _ = http.NewRequest("GET", activationURL, strings.NewReader(""))
+	q := request.URL.Query()
+	q.Add("activation_code", "iDoNotExist")
+	request.URL.RawQuery = q.Encode()
+
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected StatusBadRequest on invalid activationCode but got '%d'", response.Code)
+	}
 }

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -925,3 +925,15 @@ func TestRegisteredPage(t *testing.T) {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusOK, response.Code)
 	}
 }
+
+func TestActivation(t *testing.T) {
+	handler := InitTestHttpHandler(t)
+	const activationURL = "/oauth/activation"
+
+	request, _ := http.NewRequest("GET", activationURL, strings.NewReader(""))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected StatusBadRequest on empty activationCode but got '%d'", response.Code)
+	}
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -35,6 +35,7 @@ func RegisterRoutes(r *mux.Router) {
 	oauth.HandleFunc("/registration_page", RegistrationPage).Methods("GET")
 	oauth.HandleFunc("/registration", Registration).Methods("POST")
 	oauth.HandleFunc("/registered_page", RegisteredPage).Methods("GET")
+	oauth.HandleFunc("/activation", Activation).Methods("GET")
 	oauth.HandleFunc("/token", Token).
 		Methods("POST")
 	oauth.HandleFunc("/validate/{token}", Validate).


### PR DESCRIPTION
An account will be activated, if the URL query contains the key "activation_code" with the value of a non-disabled account with the same code. Upon activation, the activation code will be removed from the database.
If any problems occur (missing URL query, disabled account, etc), the error page will be displayed.
- added activation function to web/oauth
- added activation template
- added tests
