### PR TITLE
Password reset, Part I

### DIFF
--- a/data/account.go
+++ b/data/account.go
@@ -144,6 +144,23 @@ func GetAccountDisabled(uuid string) (*Account, bool) {
 	return account, err == nil
 }
 
+// SetPasswordReset updates the password reset code with a new token, if an
+// account can be found, that is non disabled and has either email or login of a provided credential.
+// Returns false, if no non-disabled account with the credential as email or login can be found.
+func SetPasswordReset(credential string) (*Account, bool) {
+	const q = `UPDATE Accounts SET resetpwcode=$2
+		   WHERE NOT isdisabled AND (login=$1 OR email=$1) RETURNING *`
+
+	code := util.RandomToken()
+	account := &Account{}
+	err := database.Get(account, q, credential, code)
+	if err != nil && err != sql.ErrNoRows {
+		panic(err)
+	}
+
+	return account, err == nil
+}
+
 // SetPassword hashes the plain text password and
 // sets PWHash to the new value.
 func (acc *Account) SetPassword(plain string) error {

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -171,6 +171,62 @@ func TestGetAccountDisabled(t *testing.T) {
 	}
 }
 
+func TestSetPasswordReset(t *testing.T) {
+	defer util.FailOnPanic(t)
+	InitTestDb(t)
+
+	const disabledLogin = "inact_log4"
+	const disabledEmail = "email4@example.com"
+	const enabledLogin = "inact_log1"
+	const enabledEmail = "email1@example.com"
+
+	// Test empty credential
+	_, ok := SetPasswordReset("")
+	if ok {
+		t.Error("Account should not have been updated using an empty credential")
+	}
+
+	// Test non existing credential
+	_, ok = SetPasswordReset("iDoNotExist")
+	if ok {
+		t.Error("Account should not have been updated using non existing credential")
+	}
+
+	// Test valid login of disabled account
+	_, ok = SetPasswordReset(disabledLogin)
+	if ok {
+		t.Error("Account should not have been updated using disabled account login")
+	}
+
+	// Test valid email of disabled account
+	_, ok = SetPasswordReset(disabledEmail)
+	if ok {
+		t.Error("Account should not have been updated using disabled account email")
+	}
+
+	// Test valid update using login
+	account, ok := SetPasswordReset(enabledLogin)
+	if !ok {
+		t.Errorf("Account should have been updated using valid account login '%s'", enabledLogin)
+	}
+	if account.ResetPWCode.String == "" {
+		t.Errorf("Account should have reset pw code, but was empty (using login '%s')", enabledLogin)
+	}
+
+	// Test valid update using email
+	old := account.ResetPWCode.String
+	account, ok = SetPasswordReset(enabledEmail)
+	if !ok {
+		t.Errorf("Account should have been updated using valid account email '%s'", enabledEmail)
+	}
+	if account.ResetPWCode.String == "" {
+		t.Errorf("Account should have reset pw code, but was empty (using email '%s')", enabledEmail)
+	}
+	if account.ResetPWCode.String == old {
+		t.Errorf("Account should have new reset pw code, but was unchanged (using email '%s')", enabledEmail)
+	}
+}
+
 func TestAccount_SetPassword(t *testing.T) {
 	acc := &Account{}
 	acc.SetPassword("foobar")

--- a/resources/templates/activation.html
+++ b/resources/templates/activation.html
@@ -1,6 +1,0 @@
-{{ define "content" }}
-
-<h1>Account activation</h1>
-<div>Congratulation {{ .FirstName }} {{ .LastName }}! The account for {{ .Login }} has been activated and can now be used.</div>
-
-{{ end }}

--- a/resources/templates/registered.html
+++ b/resources/templates/registered.html
@@ -1,6 +1,0 @@
-{{ define "content" }}
-
-<h1>Account registered</h1>
-<p>Your account activation is pending. An e-mail with an activation code has been sent to your e-mail address.</p>
-
-{{ end }}

--- a/resources/templates/resetinit.html
+++ b/resources/templates/resetinit.html
@@ -7,4 +7,23 @@
     An e-mail with an activation code will be sent to your e-mail address.
 </div>
 
+<hr><br />
+
+<form action="/oauth/reset_init" method="post" class="form-horizontal">
+    <div class="form-group">
+        <label for="credential" class="col-sm-3 control-label">Login or e-mail address</label>
+        <div class="col-sm-9 {{ if .ErrMessage }}has-error{{ end }}">
+            <input class="form-control" id="credential" name="credential" placeholder="Login or e-mail address" value="{{ .Credential }}">
+            {{ if .ErrMessage }}
+                <span class="help-block">{{ .ErrMessage }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+            <button type="submit" class="btn btn-default">Reset password</button>
+        </div>
+    </div>
+</form>
+
 {{ end }}

--- a/resources/templates/resetinit.html
+++ b/resources/templates/resetinit.html
@@ -1,0 +1,10 @@
+{{ define "content" }}
+
+<h1>Reset Password</h1>
+
+<div>
+    If you want to reset your password, please enter your login or your registered e-mail address below.
+    An e-mail with an activation code will be sent to your e-mail address.
+</div>
+
+{{ end }}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -943,4 +943,16 @@ func ResetInit(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("Update pw code '%s' of account with login '%s' and email '%s'\n",
 		account.ResetPWCode.String, account.Login, account.Email)
+
+	head := "Success!"
+	message := "An e-mail with a password reset token has been sent to your e-mail address. "
+	message += "Please follow the contained link to reset your password. "
+	message += "Please note that your account will stay deactivated until your password reset has been completed."
+	info := struct {
+		Header  string
+		Message string
+	}{head, message}
+
+	tmpl := conf.MakeTemplate("success.html")
+	err = tmpl.ExecuteTemplate(w, "layout", info)
 }

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -882,3 +882,14 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 }
+
+// ResetInitPage provides an input form for resetting an account password
+func ResetInitPage(w http.ResponseWriter, r *http.Request) {
+	tmpl := conf.MakeTemplate("resetinit.html")
+	w.Header().Add("Cache-Control", "no-store")
+	w.Header().Add("Content-Type", "text/html")
+	err := tmpl.ExecuteTemplate(w, "layout", &struct{}{})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -883,12 +883,20 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type credentialData struct {
+	Credential string
+	ErrMessage string
+}
+
 // ResetInitPage provides an input form for resetting an account password
 func ResetInitPage(w http.ResponseWriter, r *http.Request) {
+
+	credData := &credentialData{}
+
 	tmpl := conf.MakeTemplate("resetinit.html")
 	w.Header().Add("Cache-Control", "no-store")
 	w.Header().Add("Content-Type", "text/html")
-	err := tmpl.ExecuteTemplate(w, "layout", &struct{}{})
+	err := tmpl.ExecuteTemplate(w, "layout", credData)
 	if err != nil {
 		panic(err)
 	}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -873,11 +873,19 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
-	tmpl := conf.MakeTemplate("activation.html")
+	head := "Account activation"
+	message := fmt.Sprintf("Congratulation %s %s! The account for %s has been activated and can now be used.",
+		account.FirstName, account.LastName, account.Login)
+	info := struct {
+		Header  string
+		Message string
+	}{head, message}
+
+	tmpl := conf.MakeTemplate("success.html")
 	w.Header().Add("Cache-Control", "no-store")
 	w.Header().Add("Content-Type", "text/html")
 
-	err = tmpl.ExecuteTemplate(w, "layout", account)
+	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
 		panic(err)
 	}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -838,10 +838,19 @@ func Registration(w http.ResponseWriter, r *http.Request) {
 
 // RegisteredPage displays information about how a newly created gin account can be activated.
 func RegisteredPage(w http.ResponseWriter, r *http.Request) {
-	tmpl := conf.MakeTemplate("registered.html")
+	head := "Account registered"
+	message := "Your account activation is pending. "
+	message += "An e-mail with an activation code has been sent to your e-mail address."
+
+	info := struct {
+		Header  string
+		Message string
+	}{head, message}
+
+	tmpl := conf.MakeTemplate("success.html")
 	w.Header().Add("Cache-Control", "no-store")
 	w.Header().Add("Content-Type", "text/html")
-	err := tmpl.ExecuteTemplate(w, "layout", &struct{}{})
+	err := tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
 		panic(err)
 	}

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -1074,3 +1074,16 @@ func TestActivation(t *testing.T) {
 			account.ActivationCode.String, account.ActivationCode.Valid)
 	}
 }
+
+func TestResetInitPage(t *testing.T) {
+	handler := InitTestHttpHandler(t)
+	const resetURL = "/oauth/reset_init_page"
+
+	request, _ := http.NewRequest("GET", resetURL, strings.NewReader(""))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+}

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -1168,4 +1168,7 @@ func TestResetInit(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Errorf("Expected StatusOK but got '%d'", response.Code)
 	}
+	if response.Header().Get("Warning") != "" {
+		t.Errorf("Expected empty warning message but got '%s'", response.Header().Get("Warning"))
+	}
 }

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -1087,3 +1087,85 @@ func TestResetInitPage(t *testing.T) {
 		t.Errorf("Expected StatusOK but got '%d'", response.Code)
 	}
 }
+
+func TestResetInit(t *testing.T) {
+	handler := InitTestHttpHandler(t)
+
+	const resetInitURL = "/oauth/reset_init"
+	const disabledLogin = "inact_log4"
+	const disabledEmail = "email4@example.com"
+	const enabledLogin = "inact_log1"
+
+	// Test post empty body
+	request, _ := http.NewRequest("POST", resetInitURL, strings.NewReader(""))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Please enter your login or e-mail address" {
+		t.Errorf("Expected empty id field message but got '%s'", response.Header().Get("Warning"))
+	}
+
+	mkBody := &url.Values{}
+	mkBody.Add("Credential", "iDoNotExist")
+
+	// Test invalid login
+	request, _ = http.NewRequest("POST", resetInitURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Invalid login or e-mail address" {
+		t.Errorf("Expected invalid login message but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test login of disabled account
+	mkBody = &url.Values{}
+	mkBody.Add("Credential", disabledLogin)
+
+	request, _ = http.NewRequest("POST", resetInitURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Invalid login or e-mail address" {
+		t.Errorf("Expected invalid login message but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test e-mail of disabled account
+	mkBody = &url.Values{}
+	mkBody.Add("Credential", disabledEmail)
+
+	request, _ = http.NewRequest("POST", resetInitURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Invalid login or e-mail address" {
+		t.Errorf("Expected invalid login message but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test valid update using login
+	mkBody = &url.Values{}
+	mkBody.Add("Credential", enabledLogin)
+
+	request, _ = http.NewRequest("POST", resetInitURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK but got '%d'", response.Code)
+	}
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -38,6 +38,7 @@ func RegisterRoutes(r *mux.Router) {
 	oauth.HandleFunc("/registration", Registration).Methods("POST")
 	oauth.HandleFunc("/registered_page", RegisteredPage).Methods("GET")
 	oauth.HandleFunc("/activation", Activation).Methods("GET")
+	oauth.HandleFunc("/reset_init_page", ResetInitPage).Methods("GET")
 	oauth.HandleFunc("/token", Token).
 		Methods("POST")
 	oauth.HandleFunc("/validate/{token}", Validate).

--- a/web/routes.go
+++ b/web/routes.go
@@ -39,6 +39,7 @@ func RegisterRoutes(r *mux.Router) {
 	oauth.HandleFunc("/registered_page", RegisteredPage).Methods("GET")
 	oauth.HandleFunc("/activation", Activation).Methods("GET")
 	oauth.HandleFunc("/reset_init_page", ResetInitPage).Methods("GET")
+	oauth.HandleFunc("/reset_init", ResetInit).Methods("POST")
 	oauth.HandleFunc("/token", Token).
 		Methods("POST")
 	oauth.HandleFunc("/validate/{token}", Validate).


### PR DESCRIPTION
When providing a valid credential (login or an e-mail address) of a non-disabled account, the corresponding account will be updated with a password reset token.
- added SetPasswordReset: updates an account with a new reset password code, if a valid credential (login or e-mail address) of a non-disabled account is provided.
- added resetinit.html: credential entry form
- added ResetInitPage: provides an input form for resetting an account password
- added ResetInit: checks whether a provided credential belongs to a non-disabled account and updates this account. Displays "success.html", if the update was success; otherwise displays the credential entry form again.
- removed "activation.html" and "registered.html" and updated the functions "Activation" and "RegisteredPage" to display "success.html" instead.
