### PR TITLE
Password reset, Part II

### DIFF
--- a/resources/templates/reset.html
+++ b/resources/templates/reset.html
@@ -3,7 +3,7 @@
     <h1>Enter new password</h1>
     <hr /><br>
 
-    <form action="" method="post" class="form-horizontal">
+    <form action="/oauth/reset" method="post" class="form-horizontal">
 
         <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
             <label for="password-input" class="col-sm-3 control-label">Password *</label>

--- a/resources/templates/reset.html
+++ b/resources/templates/reset.html
@@ -1,0 +1,37 @@
+{{ define "content" }}
+
+    <h1>Enter new password</h1>
+    <hr /><br>
+
+    <form action="" method="post" class="form-horizontal">
+
+        <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+            <label for="password-input" class="col-sm-3 control-label">Password *</label>
+            <div class="col-sm-9">
+                <input type="password" class="form-control" id="password-input"
+                       name="password" placeholder="Password" maxlength="512">
+            </div>
+        </div>
+
+        <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+            <label for="password-control" class="col-sm-3 control-label">Re-enter password *</label>
+            <div class="col-sm-9">
+                <input type="password" class="form-control" id="password-control"
+                       name="password_control" placeholder="Password" maxlength="512">
+                {{ if .FieldErrors.password }}
+                    <span class="help-block">{{ .FieldErrors.password }}</span>
+                {{ end }}
+            </div>
+        </div>
+
+        <input type="hidden" id="reset_code" name="reset_code" value="{{ .ResetCode }}">
+
+        <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3">
+                <button type="submit" class="btn btn-default">Send</button>
+            </div>
+        </div>
+
+    </form>
+
+{{ end }}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -800,18 +800,21 @@ func Registration(w http.ResponseWriter, r *http.Request) {
 	if pw.Password != pw.PasswordControl {
 		valAccount.FieldErrors["password"] = "Provided password did not match password control"
 		if valAccount.Message == "" {
-			valAccount.Message = "Provided password did not match password control"
+			valAccount.Message = valAccount.FieldErrors["password"]
 		}
 	}
 	if pw.Password == "" || pw.PasswordControl == "" {
 		valAccount.FieldErrors["password"] = "Please enter password and password control"
 		if valAccount.Message == "" {
-			valAccount.Message = "Please enter password and password control"
+			valAccount.Message = valAccount.FieldErrors["password"]
 		}
 	}
 	if len(pw.Password) > 512 || len(pw.PasswordControl) > 512 {
 		valAccount.FieldErrors["password"] =
 			fmt.Sprintf("Entry too long, please shorten to %d characters", 512)
+		if valAccount.Message == "" {
+			valAccount.Message = valAccount.FieldErrors["password"]
+		}
 	}
 
 	if valAccount.Message != "" {

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -1015,3 +1015,77 @@ func ResetPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html")
 	err = tmpl.ExecuteTemplate(w, "layout", hidden)
 }
+
+// Reset checks whether a submitted password reset code exists and is still valid. It further checks,
+// if submitted password and confirm password are identical and updates the account corresponding
+// to the password reset code with the new password. This update further removes any existing
+// password reset and account activation codes.
+func Reset(w http.ResponseWriter, r *http.Request) {
+	formData := &struct {
+		ResetCode       string
+		Password        string
+		PasswordControl string
+		*util.ValidationError
+	}{}
+
+	err := util.ReadFormIntoStruct(r, formData, true)
+	if err != nil {
+		panic(err)
+	}
+
+	account, exists := data.GetAccountByResetPWCode(formData.ResetCode)
+	if !exists {
+		PrintErrorHTML(w, r, "Your request is invalid or outdated. Please request a new reset code.",
+			http.StatusNotFound)
+		return
+	}
+
+	formData.ValidationError = &util.ValidationError{FieldErrors: make(map[string]string)}
+	if formData.Password != formData.PasswordControl {
+		formData.FieldErrors["password"] = "Provided password did not match password control"
+		formData.Message = formData.FieldErrors["password"]
+	}
+	if formData.Password == "" || formData.PasswordControl == "" {
+		formData.FieldErrors["password"] = "Please enter password and password control"
+		formData.Message = formData.FieldErrors["password"]
+	}
+	if len(formData.Password) > 512 || len(formData.PasswordControl) > 512 {
+		formData.FieldErrors["password"] =
+			fmt.Sprintf("Entry too long, please shorten to %d characters", 512)
+		formData.Message = formData.FieldErrors["password"]
+	}
+
+	if formData.FieldErrors["password"] != "" {
+		formData.Password = ""
+		formData.PasswordControl = ""
+		tmpl := conf.MakeTemplate("reset.html")
+		w.Header().Add("Cache-Control", "no-store")
+		w.Header().Add("Content-Type", "text/html")
+		w.Header().Add("Warning", formData.Message)
+		err := tmpl.ExecuteTemplate(w, "layout", formData)
+		if err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	account.SetPassword(formData.Password)
+	account.ActivationCode.Valid = false
+	account.ResetPWCode.Valid = false
+	err = account.Update()
+	if err != nil {
+		panic(err)
+	}
+
+	head := "Your password has been reset!"
+	message := "You can now login using your new password."
+	info := struct {
+		Header  string
+		Message string
+	}{head, message}
+
+	tmpl := conf.MakeTemplate("success.html")
+	w.Header().Add("Cache-Control", "no-store")
+	w.Header().Add("Content-Type", "text/html")
+	err = tmpl.ExecuteTemplate(w, "layout", info)
+}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -980,26 +980,23 @@ func ResetInit(w http.ResponseWriter, r *http.Request) {
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 }
 
-// ResetPage checks whether a submitted password reset code exists and is still valid.
-// Display password entry fields if valid, an error message otherwise.
+// ResetPage checks whether a password reset code submitted by request URI query exists and is still valid.
+// Display enter password form if valid, an error message otherwise.
 func ResetPage(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
-		fmt.Println("Request was malformed")
 		PrintErrorHTML(w, r, "Request was malformed", http.StatusBadRequest)
 		return
 	}
 
 	code := r.Form.Get("reset_code")
 	if code == "" {
-		fmt.Println("Request was malformed")
 		PrintErrorHTML(w, r, "Request was malformed", http.StatusBadRequest)
 		return
 	}
 
 	_, exists := data.GetAccountByResetPWCode(code)
 	if !exists {
-		fmt.Println("Your request is invalid or outdated. Please request a new reset code.")
 		PrintErrorHTML(w, r, "Your request is invalid or outdated. Please request a new reset code.",
 			http.StatusNotFound)
 		return
@@ -1017,9 +1014,9 @@ func ResetPage(w http.ResponseWriter, r *http.Request) {
 }
 
 // Reset checks whether a submitted password reset code exists and is still valid. It further checks,
-// if submitted password and confirm password are identical and updates the account corresponding
-// to the password reset code with the new password. This update further removes any existing
-// password reset and account activation codes.
+// whether posted password and confirm password are identical and updates the account associated with
+// the password reset code with the new password. This update further removes any existing
+// password reset and account activation codes rendering the account active.
 func Reset(w http.ResponseWriter, r *http.Request) {
 	formData := &struct {
 		ResetCode       string

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -1226,3 +1226,167 @@ func TestResetPage(t *testing.T) {
 		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
 	}
 }
+
+func TestReset(t *testing.T) {
+	handler := InitTestHttpHandler(t)
+	const resetURL = "/oauth/reset"
+	const codeKey = "ResetCode"
+	const codeInvalid = "iDoNotExist"
+	const codeDisabled = "rc_c"
+	const codeValid = "rc_a"
+	const codeValidInactive = "rc_b"
+
+	// Test empty body
+	request, _ := http.NewRequest("POST", resetURL, strings.NewReader(""))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Errorf("Expected StatusNotFound on missing reset code but got '%d'", response.Code)
+	}
+
+	// Test invalid password reset code
+	mkBody := &url.Values{}
+	mkBody.Add(codeKey, codeInvalid)
+
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Errorf("Expected StatusNotFound on invalid reset code but got '%d'", response.Code)
+	}
+
+	// Test valid password reset code of disabled account
+	mkBody.Set(codeKey, codeDisabled)
+
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Errorf("Expected StatusNotFound on disabled reset code but got '%d'", response.Code)
+	}
+
+	// Test valid password reset code, missing password
+	mkBody.Set(codeKey, codeValid)
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Please enter password and password control" {
+		t.Errorf("Expected empty password warning but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test valid password reset code, password and password control missmatch
+	mkBody.Add("Password", "pw")
+	mkBody.Add("PasswordControl", "pwcontrol")
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Provided password did not match password control" {
+		t.Errorf("Expected empty password warning but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test valid password reset code, password too long
+	s := []string{}
+	for i := 0; i < 513; i++ {
+		s = append(s, "s")
+	}
+	js := strings.Join(s, "")
+
+	mkBody.Set("Password", js)
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
+	}
+	if response.Header().Get("Warning") != "Entry too long, please shorten to 512 characters" {
+		t.Errorf("Expected empty password warning but got '%s'", response.Header().Get("Warning"))
+	}
+
+	// Test valid password reset code, reset of pw code
+	account, exists := data.GetAccountByResetPWCode(codeValid)
+	if !exists {
+		t.Errorf("Account with reset code '%s' does not exist", codeValid)
+	}
+	id := account.UUID
+	_, exists = data.GetAccount(id)
+	if exists {
+		t.Errorf("Account with id '%s' reset code '%s' should not be active", id, codeValid)
+	}
+	pwHash := account.PWHash
+
+	mkBody.Set("Password", "pw")
+	mkBody.Set("PasswordControl", "pw")
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
+	}
+
+	account, exists = data.GetAccount(id)
+	if !exists {
+		t.Errorf("Account with id '%s' should be active", id)
+	}
+	if account.PWHash == pwHash {
+		t.Errorf("Password of Account with id '%s' has not been updated", id)
+	}
+	if account.ResetPWCode.String != "" {
+		t.Errorf("Password reset code of Account with id '%s' has not been deleted", id)
+	}
+
+	// Test valid password reset code, reset of pw code, reset of activation code
+	account, exists = data.GetAccountByResetPWCode(codeValidInactive)
+	if !exists {
+		t.Errorf("Account with reset code '%s' does not exist", codeValidInactive)
+	}
+	id = account.UUID
+	_, exists = data.GetAccount(id)
+	if exists {
+		t.Errorf("Account with id '%s' reset code '%s' should not be active", id, codeValidInactive)
+	}
+	pwHash = account.PWHash
+
+	mkBody.Set(codeKey, codeValidInactive)
+	request, _ = http.NewRequest("POST", resetURL, strings.NewReader(mkBody.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected StatusOK on valid reset code but got '%d'", response.Code)
+	}
+
+	account, exists = data.GetAccount(id)
+	if !exists {
+		t.Errorf("Account with id '%s' should be active", id)
+	}
+	if account.PWHash == pwHash {
+		t.Errorf("Password of Account with id '%s' has not been updated", id)
+	}
+	if account.ResetPWCode.String != "" {
+		t.Errorf("Password reset code of Account with id '%s' has not been removed", id)
+	}
+	if account.ActivationCode.String != "" {
+		t.Errorf("Activation code of Account with id '%s' has not been removed", id)
+	}
+}

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -1028,7 +1028,7 @@ func TestActivation(t *testing.T) {
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusNotFound {
-		t.Errorf("Expected StatusBadRequest on invalid activationCode but got '%d'", response.Code)
+		t.Errorf("Expected StatusNotFound on invalid activationCode but got '%d'", response.Code)
 	}
 
 	// Test activation code of disabled account
@@ -1040,7 +1040,7 @@ func TestActivation(t *testing.T) {
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusNotFound {
-		t.Errorf("Expected StatusBadRequest on disabled account but got '%d'", response.Code)
+		t.Errorf("Expected StatusNotFound on disabled account but got '%d'", response.Code)
 	}
 
 	// Test valid activation

--- a/web/routes.go
+++ b/web/routes.go
@@ -40,6 +40,7 @@ func RegisterRoutes(r *mux.Router) {
 	oauth.HandleFunc("/activation", Activation).Methods("GET")
 	oauth.HandleFunc("/reset_init_page", ResetInitPage).Methods("GET")
 	oauth.HandleFunc("/reset_init", ResetInit).Methods("POST")
+	oauth.HandleFunc("/reset_page", ResetPage).Methods("GET")
 	oauth.HandleFunc("/token", Token).
 		Methods("POST")
 	oauth.HandleFunc("/validate/{token}", Validate).

--- a/web/routes.go
+++ b/web/routes.go
@@ -41,6 +41,7 @@ func RegisterRoutes(r *mux.Router) {
 	oauth.HandleFunc("/reset_init_page", ResetInitPage).Methods("GET")
 	oauth.HandleFunc("/reset_init", ResetInit).Methods("POST")
 	oauth.HandleFunc("/reset_page", ResetPage).Methods("GET")
+	oauth.HandleFunc("/reset", Reset).Methods("POST")
 	oauth.HandleFunc("/token", Token).
 		Methods("POST")
 	oauth.HandleFunc("/validate/{token}", Validate).


### PR DESCRIPTION
Sending a valid reset password code via a GET request results in the display of a password entry form. When a valid
new password is posted, the account associated with the password reset code is updated and any reset password code
or activation code are removed rendering the account active.
- added password entry form page
- added function ResetPage
- added function Reset
- added tests for new functions
