### PR TITLE
Remove unused accounts

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -24,10 +24,11 @@ import (
 
 // The unit of all life times and intervals is minute
 const (
-	defaultSessionLifeTime  = 2880
-	defaultTokenLifeTime    = 1440
-	defaultGrantReqLifeTime = 15
-	defaultCleanerInterval  = 15
+	defaultSessionLifeTime       = 2880
+	defaultTokenLifeTime         = 1440
+	defaultGrantReqLifeTime      = 15
+	defaultUnusedAccountLifeTime = 10080
+	defaultCleanerInterval       = 15
 )
 
 // Default smtp settings
@@ -59,13 +60,14 @@ func SetResourcesPath(res string) {
 
 // ServerConfig provides several general configuration parameters for gin-auth
 type ServerConfig struct {
-	Host             string
-	Port             int
-	BaseURL          string
-	SessionLifeTime  time.Duration
-	TokenLifeTime    time.Duration
-	GrantReqLifeTime time.Duration
-	CleanerInterval  time.Duration
+	Host                  string
+	Port                  int
+	BaseURL               string
+	SessionLifeTime       time.Duration
+	TokenLifeTime         time.Duration
+	GrantReqLifeTime      time.Duration
+	UnusedAccountLifeTime time.Duration
+	CleanerInterval       time.Duration
 }
 
 var serverConfig *ServerConfig
@@ -113,13 +115,14 @@ func GetServerConfig() *ServerConfig {
 
 		config := &struct {
 			Http struct {
-				Host             string `yaml:"Host"`
-				Port             int    `yaml:"Port"`
-				BaseURL          string `yaml:"BaseURL"`
-				SessionLifeTime  int    `yaml:"SessionLifeTime"`
-				TokenLifeTime    int    `yaml:"TokenLifeTime"`
-				GrantReqLifeTime int    `yaml:"GrantReqLifeTime"`
-				CleanerInterval  int    `yaml:"CleanerInterval"`
+				Host                  string `yaml:"Host"`
+				Port                  int    `yaml:"Port"`
+				BaseURL               string `yaml:"BaseURL"`
+				SessionLifeTime       int    `yaml:"SessionLifeTime"`
+				TokenLifeTime         int    `yaml:"TokenLifeTime"`
+				GrantReqLifeTime      int    `yaml:"GrantReqLifeTime"`
+				UnusedAccountLifeTime int    `yaml:"UnusedAccountLifeTime"`
+				CleanerInterval       int    `yaml:"CleanerInterval"`
 			}
 		}{}
 		err = yaml.Unmarshal(content, config)
@@ -144,18 +147,22 @@ func GetServerConfig() *ServerConfig {
 		if config.Http.GrantReqLifeTime == 0 {
 			config.Http.GrantReqLifeTime = defaultGrantReqLifeTime
 		}
+		if config.Http.UnusedAccountLifeTime == 0 {
+			config.Http.UnusedAccountLifeTime = defaultUnusedAccountLifeTime
+		}
 		if config.Http.CleanerInterval == 0 {
 			config.Http.CleanerInterval = defaultCleanerInterval
 		}
 
 		serverConfig = &ServerConfig{
-			Host:             config.Http.Host,
-			Port:             config.Http.Port,
-			BaseURL:          config.Http.BaseURL,
-			SessionLifeTime:  time.Duration(config.Http.SessionLifeTime) * time.Minute,
-			TokenLifeTime:    time.Duration(config.Http.TokenLifeTime) * time.Minute,
-			GrantReqLifeTime: time.Duration(config.Http.GrantReqLifeTime) * time.Minute,
-			CleanerInterval:  time.Duration(config.Http.CleanerInterval) * time.Minute,
+			Host:                  config.Http.Host,
+			Port:                  config.Http.Port,
+			BaseURL:               config.Http.BaseURL,
+			SessionLifeTime:       time.Duration(config.Http.SessionLifeTime) * time.Minute,
+			TokenLifeTime:         time.Duration(config.Http.TokenLifeTime) * time.Minute,
+			GrantReqLifeTime:      time.Duration(config.Http.GrantReqLifeTime) * time.Minute,
+			UnusedAccountLifeTime: time.Duration(config.Http.UnusedAccountLifeTime) * time.Minute,
+			CleanerInterval:       time.Duration(config.Http.CleanerInterval) * time.Minute,
 		}
 	}
 

--- a/data/account.go
+++ b/data/account.go
@@ -230,6 +230,19 @@ func (acc *Account) Update() error {
 	return err
 }
 
+// RemoveActivationCode is the only way to remove an ActivationCode from an Account,
+// since this field should never be set via the Update function by accident.
+func (acc *Account) RemoveActivationCode() error {
+	const q = `UPDATE Accounts
+	           SET activationcode = NULL
+	           WHERE uuid=$1
+	           RETURNING *`
+
+	err := database.Get(acc, q, acc.UUID)
+
+	return err
+}
+
 // Validate the content of an Account.
 // First name, last name, login, email, institute, department, city and country must not be empty;
 // Title, first name, middle name last name, login, email, institute, department, city

--- a/data/account.go
+++ b/data/account.go
@@ -214,17 +214,19 @@ func (acc *Account) SSHKeys() []SSHKey {
 // Update stores the new values of an Account in the database.
 // New values for Login and CreatedAt are ignored. UpdatedAt will be set
 // automatically to the current date and time.
+// Field ActivationCode is not set via this update function, since this field fulfills a special role.
+// It can only be set to a value once by account create and can only be set to null via its own function.
 func (acc *Account) Update() error {
 	const q = `UPDATE Accounts
-	           SET (pwHash, email, isemailpublic, title, firstName, middleName, lastName, institute, department, city,
-	                country, isaffiliationpublic, activationCode, resetPWCode, isDisabled, updatedAt) =
-	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now())
-	           WHERE uuid=$16
+	           SET (pwHash, email, isemailpublic, title, firstName, middleName, lastName, institute,
+	                department, city, country, isaffiliationpublic, resetPWCode, isDisabled, updatedAt) =
+	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now())
+	           WHERE uuid=$15
 	           RETURNING *`
 
 	err := database.Get(acc, q, acc.PWHash, acc.Email, acc.IsEmailPublic, acc.Title, acc.FirstName, acc.MiddleName,
 		acc.LastName, acc.Institute, acc.Department, acc.City, acc.Country, acc.IsAffiliationPublic,
-		acc.ActivationCode, acc.ResetPWCode, acc.IsDisabled, acc.UUID)
+		acc.ResetPWCode, acc.IsDisabled, acc.UUID)
 
 	// TODO There is a lot of room for improvement here concerning errors about constraints for certain fields
 	return err

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -287,7 +287,6 @@ func TestAccount_Update(t *testing.T) {
 	newFirstName := "I am actually not Alice"
 	newMiddleName := "and my last name is"
 	newLastName := "Badchild"
-	newActivationCode := "activation code"
 	newResetPWCode := "reset password code"
 
 	acc, ok := GetAccount(uuidAlice)
@@ -333,19 +332,6 @@ func TestAccount_Update(t *testing.T) {
 	}
 	if acc.LastName != newLastName {
 		t.Error("LastName was not updated")
-	}
-
-	acc.ActivationCode = sql.NullString{String: newActivationCode, Valid: true}
-	err = acc.Update()
-	if err != nil {
-		t.Error(err)
-	}
-	acc, ok = GetAccountByActivationCode(newActivationCode)
-	if !ok {
-		t.Error("Activation code update failed")
-	}
-	if acc.ActivationCode.String != newActivationCode {
-		t.Error("Activation code was not updated")
 	}
 
 	acc.ResetPWCode = sql.NullString{String: newResetPWCode, Valid: true}

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -361,6 +361,34 @@ func TestAccount_Update(t *testing.T) {
 	}
 }
 
+func TestAccount_RemoveActivationCode(t *testing.T) {
+	InitTestDb(t)
+
+	const login = "inact_log1"
+	const activationCode = "ac_a"
+
+	acc, ok := GetAccountByLogin(login)
+	if ok {
+		t.Error("Account should not be active")
+	}
+	acc, ok = GetAccountByActivationCode(activationCode)
+	if !ok {
+		t.Error("Account does not exist")
+	}
+
+	err := acc.RemoveActivationCode()
+	if err != nil {
+		t.Errorf("An error occurred trying to remove an activation code: '%s'", err.Error())
+	}
+	acc, ok = GetAccountByLogin(login)
+	if !ok {
+		t.Error("Account should be active")
+	}
+	if acc.ActivationCode.Valid {
+		t.Error("Activation code should be empty")
+	}
+}
+
 func TestValidate(t *testing.T) {
 	InitTestDb(t)
 

--- a/resources/conf/migrations/1_initial-schema.sql
+++ b/resources/conf/migrations/1_initial-schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE SSHKeys (
   fingerprint       VARCHAR(128) PRIMARY KEY ,
   key               VARCHAR(1024) NOT NULL UNIQUE ,
   description       VARCHAR(1024) NOT NULL ,
-  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );
@@ -67,7 +67,7 @@ CREATE TABLE ClientApprovals (
   uuid              VARCHAR(36) PRIMARY KEY CHECK (char_length(uuid) = 36) ,
   scope             VARCHAR[] NOT NULL ,
   clientUUID        VARCHAR(36) NOT NULL REFERENCES Clients(uuid) ON DELETE CASCADE ,
-  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL ,
   UNIQUE (clientUUID, accountUUID)
@@ -81,7 +81,7 @@ CREATE TABLE GrantRequests (
   scopeRequested    VARCHAR[] NOT NULL ,
   redirectURI       VARCHAR(512) NOT NULL ,
   clientUUID        VARCHAR(36) NOT NULL REFERENCES Clients(uuid) ON DELETE CASCADE ,
-  accountUUID       VARCHAR(36) NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) NULL REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );
@@ -90,7 +90,7 @@ CREATE TABLE RefreshTokens (
   token             VARCHAR(512) PRIMARY KEY ,
   scope             VARCHAR[] NOT NULL ,
   clientUUID        VARCHAR(36) NOT NULL REFERENCES Clients(uuid) ON DELETE CASCADE ,
-  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );
@@ -100,7 +100,7 @@ CREATE TABLE AccessTokens (
   scope             VARCHAR[] NOT NULL ,
   expires           TIMESTAMP NOT NULL ,
   clientUUID        VARCHAR(36) NOT NULL REFERENCES Clients(uuid) ON DELETE CASCADE ,
-  accountUUID       VARCHAR(36) REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );
@@ -110,7 +110,7 @@ CREATE INDEX ON AccessTokens (expires);
 CREATE TABLE Sessions (
   token             VARCHAR(512) PRIMARY KEY ,      -- the session id
   expires           TIMESTAMP NOT NULL ,
-  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ON DELETE CASCADE ,
+  accountUUID       VARCHAR(36) NOT NULL REFERENCES Accounts(uuid) ,
   createdAt         TIMESTAMP NOT NULL ,
   updatedAt         TIMESTAMP NOT NULL
 );

--- a/resources/fixtures/testdb.sql
+++ b/resources/fixtures/testdb.sql
@@ -1,5 +1,14 @@
 -- Test fixtures to be used in tests
+DELETE FROM RefreshTokens;
+DELETE FROM AccessTokens;
+DELETE FROM Sessions;
+DELETE FROM GrantRequests;
+DELETE FROM ClientApprovals;
+DELETE FROM ClientScopeProvided;
+DELETE FROM Clients;
+DELETE FROM SSHKeys;
 DELETE FROM Accounts;
+
 INSERT INTO Accounts (uuid, login, pwHash, email, isEmailPublic, title, firstName, lastName, institute, department, city, country, isAffiliationPublic, activationCode, createdAt, updatedAt) VALUES
   ('bf431618-f696-4dca-a95d-882618ce4ef9', 'alice', '', 'aclic@foo.com', FALSE, 'Dr.', 'Alice', 'Goodchild', 'LMU', 'Biology II', 'Munich', 'Germany', FALSE, NULL, '2015-01-01 01:00:00', '2015-02-02 01:00:00'),
   ('51f5ac36-d332-4889-8023-6e033fcd8e17', 'bob', '', 'bob@foo.com', FALSE, 'Mr.', 'Bob', 'Beaver', 'LMU', 'Biology II', 'Munich', 'Germany', TRUE, NULL, '2015-01-01 01:00:00', '2015-02-02 01:00:00'),
@@ -16,17 +25,14 @@ INSERT INTO Accounts (uuid, login, pwhash, email, firstname, lastname, institute
   ('test0005-1234-6789-1234-678901234567', 'inact_log5', '', 'email5@example.com', 'fname', 'lname', 'inst', 'dep', 'cty', 'ctry', 'ac_b', NULL, TRUE, now(), now()),
   ('test0006-1234-6789-1234-678901234567', 'inact_log6', '', 'email6@example.com', 'fname', 'lname', 'inst', 'dep', 'cty', 'ctry', 'ac_d', 'rc_c', TRUE, now(), now());
 
-DELETE FROM SSHKeys;
 INSERT INTO SSHKeys (fingerprint, accountUUID, description, key, createdAt, updatedAt) VALUES
   ('A3tkBXFQWkjU6rzhkofY55G7tPR_Lmna4B-WEGVFXOQ', 'bf431618-f696-4dca-a95d-882618ce4ef9', 'Key from alice', 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLtRNg1UHUf0k0ZlkfoYod9NoDPpOgx2AStEaEk/0bIKBqWJUNAZUfc6CHooKXTP3YakgqI7/BxV2pVgJIFBI4K9yGeLu76mwTpIZUTjEw/VoOaNP/vfV0LmXvQXstXMOZkmWt1rFaLsBpL9REP7XxteZYc2tjyVqy32GsVZHh6pPNes2q1Cf+awhkV/kXjup5AXwROLzqRvYBRs8oMPFDRZEGGax/Pp+r2GTB44M8YC0p7JAL3tLDDWsLVyygFA0OGhUffHmOGGf69uhh5JHhOjp49GEGftABdjnJznrVAI/71ySt0xWHJIOgMScsUGLYJtOZE/9KVrOQgZ1UAQML bar@foo', now(), now()),
   ('x9nS_Siw6cUy0qemb10V0dSK8YQYS2BKvV5KFowitUw', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'Key from bob', 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC857PNeLe38+Q/m9gbhq8fmjD0NuyMC9g2cTSz32+S9LoUUBqQhY0IvsbLLH+0uvlBEBVrLFN+D/bUgBlJc1I+8PZUtagGcjmdBwZgaePJY4ew1xGwN9yxiFI1ICyk6NN+7HEYrB81Bl1zuNs7vQU/cZGyAybSd5onPU772cy1+Ot3iYCfZm9dY613LgOP/I6yCVPlE+385qx6IoEPXuJxi8GneIn8vMOM0zk+kVOUmRHPcJfxsuhh3nt5n3bNiapp4kHX2MH1jEHGgnPco86Js8SSZVeh81oRAPLVL3TrlNPoRC41BnZfo3eXXsIORIzW8nKe3ij8OOuXjpIqYFOL bar@foo', now(), now());
 
-DELETE FROM Clients;
 INSERT INTO Clients (uuid, name, secret, scopeWhitelist, scopeBlacklist, redirectURIs, createdAt, updatedAt) VALUES
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'gin', 'secret', '{}','{"account-admin"}','{"https://localhost:8081/login"}', now(), now()),
   ('177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'wb', 'secret', '{"account-read","repo-read"}','{"account-admin"}','{"https://localhost:8081/login"}', now(), now());
 
-DELETE FROM ClientScopeProvided;
 INSERT INTO ClientScopeProvided (clientuuid, name, description) VALUES
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-read', 'Read access to your account data'),
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-write', 'Write access to your account data'),
@@ -34,31 +40,26 @@ INSERT INTO ClientScopeProvided (clientuuid, name, description) VALUES
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'repo-read', 'Read access to your repositories and repositories shared with you'),
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'repo-write', 'Write acces to your repositories and repositories you have write access to');
 
-DELETE FROM ClientApprovals;
 INSERT INTO ClientApprovals (uuid, scope, clientUUID, accountUUID, createdAt, updatedAt) VALUES
   ('31da7869-4593-4682-b9f2-5f47987aa5fc', '{"repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('ffde3769-cb45-43c1-8afd-4fb154ddf0b0', '{"repo-write","account-write"}', '177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now());
 
-DELETE FROM GrantRequests;
 INSERT INTO GrantRequests (token, grantType, state, code, scopeRequested, redirectUri, clientUUID, accountUUID, createdAt, updatedAt) VALUES
   ('U7JIKKYI', 'code', 'OCQYDRYW', 'HGZQP6WE','{"repo-read","repo-write"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('QH92T99D', 'code', 'HD58GHV9', NULL ,'{"account-read","repo-read"}', 'https://localhost:8081/login', '177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('B4LIMIMB', 'code', '6Y4UTL24', 'C52KLSIZ','{"repo-read","repo-write"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', now(), now()),
   ('AGTBAI3D', 'code', 'GBNAM23L', 'KWANG2G4','{"account-read"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday');
 
-DELETE FROM Sessions;
 INSERT INTO Sessions (token, expires, accountUUID, createdAt, updatedAt) VALUES
   ('DNM5RS3C', 'tomorrow', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('4KDNO8T0', 'tomorrow', '51f5ac36-d332-4889-8023-6e033fcd8e17', now(), now()),
   ('2MFZZUKI', 'yesterday', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday');
 
-DELETE FROM AccessTokens;
 INSERT INTO AccessTokens (token, expires, scope, clientUUID, accountUUID, createdAt, updatedAt) VALUES
   ('3N7MP7M7', 'tomorrow', '{"account-read","account-write","repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('LJ3W7ZFK', 'yesterday', '{"account-read","account-write","repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday'),
   ('KDEW57D4', 'tomorrow', '{"account-admin","repo-admin"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', now(), now());
 
-DELETE FROM RefreshTokens;
 INSERT INTO RefreshTokens (token, scope, clientUUID, accountUUID, createdAt, updatedAt) VALUES
   ('YYPTDSVZ', '{"repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('4FKJVX3K', '{"repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday');

--- a/web/registration.go
+++ b/web/registration.go
@@ -215,8 +215,7 @@ func Activation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account.ActivationCode.Valid = false
-	err = account.Update()
+	err = account.RemoveActivationCode()
 	if err != nil {
 		panic(err)
 	}

--- a/web/reset.go
+++ b/web/reset.go
@@ -198,9 +198,12 @@ func Reset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	account.SetPassword(formData.Password)
-	account.ActivationCode.Valid = false
 	account.ResetPWCode.Valid = false
 	err = account.Update()
+	if err != nil {
+		panic(err)
+	}
+	err = account.RemoveActivationCode()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Accounts that have been created but never activated will be removed after a week.

Closes issue #64 
- unused accounts will be removed after a week
- changed account update: ActivationCode can no longer be changed by account update
- added dedicated account RemoveActivationCode function
- changed database scheme: removed account on delete cascade
