### PR TITLE
Account API endpoint to change account e-mail

### DIFF
--- a/data/account.go
+++ b/data/account.go
@@ -250,15 +250,16 @@ func (acc *Account) SSHKeys() []SSHKey {
 // automatically to the current date and time.
 // Field ActivationCode is not set via this update function, since this field fulfills a special role.
 // It can only be set to a value once by account create and can only be set to null via its own function.
+// Field email is not set via this update function, since it requires sufficient scope to change.
 func (acc *Account) Update() error {
 	const q = `UPDATE Accounts
-	           SET (pwHash, email, isemailpublic, title, firstName, middleName, lastName, institute,
+	           SET (pwHash, isemailpublic, title, firstName, middleName, lastName, institute,
 	                department, city, country, isaffiliationpublic, resetPWCode, isDisabled, updatedAt) =
-	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now())
-	           WHERE uuid=$15
+	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())
+	           WHERE uuid=$14
 	           RETURNING *`
 
-	err := database.Get(acc, q, acc.PWHash, acc.Email, acc.IsEmailPublic, acc.Title, acc.FirstName, acc.MiddleName,
+	err := database.Get(acc, q, acc.PWHash, acc.IsEmailPublic, acc.Title, acc.FirstName, acc.MiddleName,
 		acc.LastName, acc.Institute, acc.Department, acc.City, acc.Country, acc.IsAffiliationPublic,
 		acc.ResetPWCode, acc.IsDisabled, acc.UUID)
 

--- a/data/account.go
+++ b/data/account.go
@@ -177,6 +177,22 @@ func (acc *Account) VerifyPassword(plain string) bool {
 	return err == nil
 }
 
+// UpdatePassword hashes a plain text password
+// and updates the database entry of the corresponding account.
+func (acc *Account) UpdatePassword(plain string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+
+	const q = `UPDATE Accounts SET pwhash=$1 WHERE uuid=$2 RETURNING *`
+	err = database.Get(acc, q, string(hash), acc.UUID)
+	if err == nil {
+		acc.PWHash = string(hash)
+	}
+	return err
+}
+
 // UpdateEmail checks validity of a new e-mail address and updates the current account
 // with a valid new e-mail address.
 // The normal account update does not include the e-mail address for safety reasons.

--- a/data/account.go
+++ b/data/account.go
@@ -272,16 +272,16 @@ func (acc *Account) SSHKeys() []SSHKey {
 // automatically to the current date and time.
 // Field ActivationCode is not set via this update function, since this field fulfills a special role.
 // It can only be set to a value once by account create and can only be set to null via its own function.
-// Field email is not set via this update function, since it requires sufficient scope to change.
+// Fields password and email are not set via this update function, since they require sufficient scope to change.
 func (acc *Account) Update() error {
 	const q = `UPDATE Accounts
-	           SET (pwHash, isemailpublic, title, firstName, middleName, lastName, institute,
+	           SET (isemailpublic, title, firstName, middleName, lastName, institute,
 	                department, city, country, isaffiliationpublic, resetPWCode, isDisabled, updatedAt) =
-	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())
-	           WHERE uuid=$14
+	               ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, now())
+	           WHERE uuid=$13
 	           RETURNING *`
 
-	err := database.Get(acc, q, acc.PWHash, acc.IsEmailPublic, acc.Title, acc.FirstName, acc.MiddleName,
+	err := database.Get(acc, q, acc.IsEmailPublic, acc.Title, acc.FirstName, acc.MiddleName,
 		acc.LastName, acc.Institute, acc.Department, acc.City, acc.Country, acc.IsAffiliationPublic,
 		acc.ResetPWCode, acc.IsDisabled, acc.UUID)
 

--- a/data/account.go
+++ b/data/account.go
@@ -197,16 +197,15 @@ func (acc *Account) UpdatePassword(plain string) error {
 // with a valid new e-mail address.
 // The normal account update does not include the e-mail address for safety reasons.
 func (acc *Account) UpdateEmail(email string) error {
-	valErr := &util.ValidationError{FieldErrors: make(map[string]string)}
 	if !(len(email) > 2) || !strings.Contains(email, "@") {
-		valErr.Message = "Invalid e-mail address"
-		valErr.FieldErrors["email"] = "Please use a valid e-mail address"
-		return valErr
+		return &util.ValidationError{
+			Message:     "Invalid e-mail address",
+			FieldErrors: map[string]string{"email": "Please use a valid e-mail address"}}
 	}
 	if len(email) > 512 {
-		valErr.Message = "Invalid e-mail address"
-		valErr.FieldErrors["email"] = "Address too long, please shorten to 512 characters"
-		return valErr
+		return &util.ValidationError{
+			Message:     "Invalid e-mail address",
+			FieldErrors: map[string]string{"email": "Address too long, please shorten to 512 characters"}}
 	}
 	exists := &struct {
 		Email bool
@@ -218,9 +217,9 @@ func (acc *Account) UpdateEmail(email string) error {
 		panic(err)
 	}
 	if exists.Email {
-		valErr.Message = "E-Mail address already exists"
-		valErr.FieldErrors["email"] = "Please choose a different e-mail address"
-		return valErr
+		return &util.ValidationError{
+			Message:     "E-Mail address already exists",
+			FieldErrors: map[string]string{"email": "Please choose a different e-mail address"}}
 	}
 
 	const q = `UPDATE Accounts SET email=$1 WHERE uuid=$2 RETURNING *`

--- a/data/account.go
+++ b/data/account.go
@@ -178,10 +178,10 @@ func (acc *Account) VerifyPassword(plain string) bool {
 	return err == nil
 }
 
-// SetEmail checks validity of a new e-mail address and updates the current account
+// UpdateEmail checks validity of a new e-mail address and updates the current account
 // with a valid new e-mail address.
 // The normal account update does not include the e-mail address for safety reasons.
-func (acc *Account) SetEmail(email string) error {
+func (acc *Account) UpdateEmail(email string) error {
 	if !(len(email) > 2) || !strings.Contains(email, "@") {
 		return errors.New("Please use a valid e-mail address")
 	}

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -241,6 +241,58 @@ func TestAccount_SetPassword(t *testing.T) {
 	}
 }
 
+func TestAccount_SetEmail(t *testing.T) {
+	InitTestDb(t)
+	const short = "a"
+	const missing = "aaaa"
+	const valid = "testaddress12@nowhere.com"
+
+	acc, ok := GetAccount(uuidAlice)
+	if !ok {
+		t.Error("Account does not exist")
+	}
+
+	err := acc.SetEmail(short)
+	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
+		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
+	}
+
+	err = acc.SetEmail(missing)
+	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
+		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
+	}
+
+	// Test maximal length error
+	s := []string{}
+	s = append(s, "@")
+	for i := 0; i < 513; i++ {
+		s = append(s, "s")
+	}
+	js := strings.Join(s, "")
+
+	err = acc.SetEmail(js)
+	if !strings.Contains(err.Error(), "Address too long") {
+		t.Errorf("Expected e-mail address too long error but got: '%s'", err.Error())
+	}
+
+	err = acc.SetEmail(acc.Email)
+	if !strings.Contains(err.Error(), "Please choose a different e-mail address") {
+		t.Errorf("Expected choose different e-mail address error but got: '%s'", err.Error())
+	}
+
+	err = acc.SetEmail(valid)
+	if err != nil {
+		t.Errorf("Encountered unexpected error: '%s'", err.Error())
+	}
+	acc, ok = GetAccount(uuidAlice)
+	if !ok {
+		t.Error("Account does not exist")
+	}
+	if acc.Email != valid {
+		t.Errorf("Expected e-mail address to be '%s', but was '%s'", valid, acc.Email)
+	}
+}
+
 func TestAccount_Create(t *testing.T) {
 	InitTestDb(t)
 

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -243,6 +243,38 @@ func TestAccount_SetPassword(t *testing.T) {
 	}
 }
 
+func TestAccount_UpdatePassword(t *testing.T) {
+	InitTestDb(t)
+	const pw = "supersecret"
+
+	acc, ok := GetAccount(uuidAlice)
+	if !ok {
+		t.Error("Account does not exist")
+	}
+	err := acc.UpdatePassword(pw)
+	if err != nil {
+		t.Errorf("Error updating password: '%s'", err.Error())
+	}
+
+	if acc.PWHash == pw {
+		t.Error("PWHash equals plain text password")
+	}
+	if len(acc.PWHash) < 60 {
+		t.Error("PWHash is too short")
+	}
+	if !acc.VerifyPassword(pw) {
+		t.Error("Unable to verify password")
+	}
+
+	checkDb, ok := GetAccount(uuidAlice)
+	if !ok {
+		t.Error("Account does not exist")
+	}
+	if !checkDb.VerifyPassword(pw) {
+		t.Error("Password update failed")
+	}
+}
+
 func TestAccount_UpdateEmail(t *testing.T) {
 	InitTestDb(t)
 	const short = "a"

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -10,9 +10,11 @@ package data
 
 import (
 	"database/sql"
-	"github.com/G-Node/gin-auth/util"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/G-Node/gin-auth/util"
 )
 
 const (
@@ -241,7 +243,7 @@ func TestAccount_SetPassword(t *testing.T) {
 	}
 }
 
-func TestAccount_SetEmail(t *testing.T) {
+func TestAccount_UpdateEmail(t *testing.T) {
 	InitTestDb(t)
 	const short = "a"
 	const missing = "aaaa"
@@ -253,12 +255,20 @@ func TestAccount_SetEmail(t *testing.T) {
 	}
 
 	err := acc.UpdateEmail(short)
-	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
+	if reflect.TypeOf(err).String() != "*util.ValidationError" {
+		t.Errorf("Expected valid e-mail address error but got: '%s', '%s'",
+			reflect.TypeOf(err).String(), err.Error())
+	}
+	if !strings.Contains(err.(*util.ValidationError).FieldErrors["email"], "Please use a valid e-mail address") {
 		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
 	}
 
 	err = acc.UpdateEmail(missing)
-	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
+	if reflect.TypeOf(err).String() != "*util.ValidationError" {
+		t.Errorf("Expected valid e-mail address error but got: '%s', '%s'",
+			reflect.TypeOf(err).String(), err.Error())
+	}
+	if !strings.Contains(err.(*util.ValidationError).FieldErrors["email"], "Please use a valid e-mail address") {
 		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
 	}
 
@@ -271,12 +281,21 @@ func TestAccount_SetEmail(t *testing.T) {
 	js := strings.Join(s, "")
 
 	err = acc.UpdateEmail(js)
-	if !strings.Contains(err.Error(), "Address too long") {
+	if reflect.TypeOf(err).String() != "*util.ValidationError" {
+		t.Errorf("Expected e-mail address too long error but got: '%s', '%s'",
+			reflect.TypeOf(err).String(), err.Error())
+	}
+	if !strings.Contains(err.(*util.ValidationError).FieldErrors["email"], "Address too long") {
 		t.Errorf("Expected e-mail address too long error but got: '%s'", err.Error())
 	}
 
 	err = acc.UpdateEmail(acc.Email)
-	if !strings.Contains(err.Error(), "Please choose a different e-mail address") {
+	if reflect.TypeOf(err).String() != "*util.ValidationError" {
+		t.Errorf("Expected choose different e-mail address error but got: '%s', '%s'",
+			reflect.TypeOf(err).String(), err.Error())
+	}
+	if !strings.Contains(err.(*util.ValidationError).FieldErrors["email"],
+		"Please choose a different e-mail address") {
 		t.Errorf("Expected choose different e-mail address error but got: '%s'", err.Error())
 	}
 

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -333,7 +333,6 @@ func TestAccount_Update(t *testing.T) {
 	InitTestDb(t)
 
 	newLogin := "alice_in_wonderland"
-	newEmail := "alice_in_wonderland@example.com"
 	newPw := "secret"
 	newTitle := "Dr."
 	newFirstName := "I am actually not Alice"
@@ -348,7 +347,6 @@ func TestAccount_Update(t *testing.T) {
 
 	acc.SetPassword(newPw)
 	acc.Login = newLogin
-	acc.Email = newEmail
 	acc.Title = sql.NullString{String: newTitle, Valid: true}
 	acc.FirstName = newFirstName
 	acc.MiddleName = sql.NullString{String: newMiddleName, Valid: true}
@@ -369,9 +367,6 @@ func TestAccount_Update(t *testing.T) {
 	}
 	if acc.Login == newLogin {
 		t.Error("Login was updated although this should never happen")
-	}
-	if acc.Email != newEmail {
-		t.Error("Email was not updated")
 	}
 	if acc.Title.String != newTitle {
 		t.Error("Title was not updated")

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -252,12 +252,12 @@ func TestAccount_SetEmail(t *testing.T) {
 		t.Error("Account does not exist")
 	}
 
-	err := acc.SetEmail(short)
+	err := acc.UpdateEmail(short)
 	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
 		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
 	}
 
-	err = acc.SetEmail(missing)
+	err = acc.UpdateEmail(missing)
 	if !strings.Contains(err.Error(), "Please use a valid e-mail address") {
 		t.Errorf("Expected valid e-mail address error but got: '%s'", err.Error())
 	}
@@ -270,17 +270,17 @@ func TestAccount_SetEmail(t *testing.T) {
 	}
 	js := strings.Join(s, "")
 
-	err = acc.SetEmail(js)
+	err = acc.UpdateEmail(js)
 	if !strings.Contains(err.Error(), "Address too long") {
 		t.Errorf("Expected e-mail address too long error but got: '%s'", err.Error())
 	}
 
-	err = acc.SetEmail(acc.Email)
+	err = acc.UpdateEmail(acc.Email)
 	if !strings.Contains(err.Error(), "Please choose a different e-mail address") {
 		t.Errorf("Expected choose different e-mail address error but got: '%s'", err.Error())
 	}
 
-	err = acc.SetEmail(valid)
+	err = acc.UpdateEmail(valid)
 	if err != nil {
 		t.Errorf("Encountered unexpected error: '%s'", err.Error())
 	}

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -413,8 +413,8 @@ func TestAccount_Update(t *testing.T) {
 		t.Error("Account does not exist")
 	}
 
-	if !acc.VerifyPassword(newPw) {
-		t.Error("PWHash was not updated")
+	if acc.VerifyPassword(newPw) {
+		t.Error("PWHash was updated though this should not have happened via update")
 	}
 	if acc.Login == newLogin {
 		t.Error("Login was updated although this should never happen")

--- a/doc/API.md
+++ b/doc/API.md
@@ -637,6 +637,31 @@ The token scope must contain 'account-write' to change the own password.
 
 If the password was successfully changed the status code is 200 and the response body is empty.
 
+### Update account email
+
+##### URL
+
+```
+PUT https://<host>/api/accounts/<login>/email
+```
+
+##### Authorization
+
+A bearer token sent with the authorization header is required.
+The token scope must contain 'account-write' to change the own e-mail address.
+
+##### Body
+
+```json
+{
+    "password": "...",
+    "email": "...",
+}
+```
+
+##### Response
+
+If the password was successfully changed the status code is 200 and the response body is empty.
 
 
 SSH-key API

--- a/web/account.go
+++ b/web/account.go
@@ -208,9 +208,9 @@ func UpdateAccountEmail(w http.ResponseWriter, r *http.Request) {
 	dec.Decode(cred)
 
 	if !acc.VerifyPassword(cred.Password) {
-		valErr := &util.ValidationError{FieldErrors: make(map[string]string)}
-		valErr.Message = "Invalid password"
-		valErr.FieldErrors["password"] = "Invalid password"
+		valErr := &util.ValidationError{
+			Message:     "Invalid password",
+			FieldErrors: map[string]string{"password": "Invalid password"}}
 		PrintErrorJSON(w, r, valErr, http.StatusBadRequest)
 		return
 	}

--- a/web/account.go
+++ b/web/account.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/G-Node/gin-auth/conf"
 	"github.com/G-Node/gin-auth/data"
 	"github.com/G-Node/gin-auth/util"
 	"github.com/gorilla/mux"
@@ -175,6 +176,68 @@ func UpdateAccountPassword(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		PrintErrorJSON(w, r, err, http.StatusInternalServerError)
+		return
+	}
+}
+
+// UpdateAccountEmail parses an e-mail address and the account password
+// from a JSON request body and updates the e-mail address of the authorized account.
+func UpdateAccountEmail(w http.ResponseWriter, r *http.Request) {
+
+	login := mux.Vars(r)["login"]
+	oauth, ok := OAuthToken(r)
+	if !ok {
+		panic("Missing OAuth token")
+	}
+
+	acc, ok := data.GetAccountByLogin(login)
+	if !ok {
+		PrintErrorJSON(w, r, "The requested account does not exist", http.StatusNotFound)
+		return
+	}
+
+	if oauth.Token.AccountUUID.String != acc.UUID || !oauth.Match.Contains("account-write") {
+		PrintErrorJSON(w, r, "Unauthorized account access", http.StatusUnauthorized)
+		return
+	}
+
+	cred := &struct {
+		Password string `json:"password"`
+		Email    string `json:"email"`
+	}{}
+
+	dec := json.NewDecoder(r.Body)
+	dec.Decode(cred)
+
+	if !acc.VerifyPassword(cred.Password) {
+		PrintErrorJSON(w, r, "Wrong password", http.StatusBadRequest)
+		return
+	}
+
+	err := acc.SetEmail(cred.Email)
+	if err != nil {
+		PrintErrorJSON(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	tmplFields := &struct {
+		From    string
+		To      string
+		Subject string
+		Body    string
+	}{}
+	tmplFields.From = conf.GetSmtpCredentials().From
+	tmplFields.To = cred.Email
+	tmplFields.Subject = "GIN account confirmation"
+	tmplFields.Body = "The e-mail address of your GIN account has been successfully changed."
+
+	content := util.MakeEmailTemplate("emailplain.txt", tmplFields)
+	disp := util.NewEmailDispatcher()
+
+	err = disp.Send([]string{cred.Email}, content.Bytes())
+	if err != nil {
+		msg := "An error occurred trying to send change e-mail address confirmation."
+		PrintErrorJSON(w, r, msg, http.StatusInternalServerError)
 		return
 	}
 }

--- a/web/account.go
+++ b/web/account.go
@@ -210,7 +210,10 @@ func UpdateAccountEmail(w http.ResponseWriter, r *http.Request) {
 	dec.Decode(cred)
 
 	if !acc.VerifyPassword(cred.Password) {
-		PrintErrorJSON(w, r, "Wrong password", http.StatusBadRequest)
+		valErr := &util.ValidationError{FieldErrors: make(map[string]string)}
+		valErr.Message = "Invalid password"
+		valErr.FieldErrors["password"] = "Invalid password"
+		PrintErrorJSON(w, r, valErr, http.StatusBadRequest)
 		return
 	}
 

--- a/web/account.go
+++ b/web/account.go
@@ -214,7 +214,7 @@ func UpdateAccountEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := acc.SetEmail(cred.Email)
+	err := acc.UpdateEmail(cred.Email)
 	if err != nil {
 		PrintErrorJSON(w, r, err, http.StatusBadRequest)
 		return

--- a/web/account.go
+++ b/web/account.go
@@ -171,9 +171,7 @@ func UpdateAccountPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account.SetPassword(pwData.PasswordNew)
-	err := account.Update()
-
+	err := account.UpdatePassword(pwData.PasswordNew)
 	if err != nil {
 		PrintErrorJSON(w, r, err, http.StatusInternalServerError)
 		return

--- a/web/account_test.go
+++ b/web/account_test.go
@@ -12,8 +12,6 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
-	"github.com/G-Node/gin-auth/conf"
-	"github.com/G-Node/gin-auth/data"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -21,6 +19,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/G-Node/gin-auth/conf"
+	"github.com/G-Node/gin-auth/data"
 )
 
 const (
@@ -311,6 +312,95 @@ func TestUpdateAccountPassword(t *testing.T) {
 	acc, _ := data.GetAccountByLogin("alice")
 	if !acc.VerifyPassword("TestTest") {
 		t.Error("Unable to verify password")
+	}
+}
+
+func TestUpdateAccountEmail(t *testing.T) {
+	const uriInvalid = "/api/accounts/idonotexist/email"
+	const uriAlice = "/api/accounts/alice/email"
+	const uriBob = "/api/accounts/bob/email"
+	const tokenInsufficient = "KDEW57D4"
+
+	jsonBody := func(pw string, email string) io.Reader {
+		cont := &struct {
+			Password string `json:"password"`
+			Email    string `json:"email"`
+		}{pw, email}
+		b, err := json.Marshal(cont)
+		if err != nil {
+			t.Error("Error marshalling content")
+		}
+		return bytes.NewReader(b)
+	}
+
+	handler := InitTestHttpHandler(t)
+
+	// missing authorization header
+	request, _ := http.NewRequest("PUT", uriAlice, strings.NewReader(""))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusUnauthorized, response.Code)
+	}
+
+	// invalid login
+	request, _ = http.NewRequest("PUT", uriInvalid, strings.NewReader(""))
+	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusNotFound, response.Code)
+	}
+
+	// insufficient scope
+	request, _ = http.NewRequest("PUT", uriBob, strings.NewReader(""))
+	request.Header.Set("Authorization", "Bearer "+tokenInsufficient)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusUnauthorized, response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "Insufficient scope") {
+		t.Errorf("Expected insufficient scope but got: \n%s", response.Body.String())
+	}
+
+	// empty Body
+	request, _ = http.NewRequest("PUT", uriAlice, strings.NewReader(""))
+	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "Wrong password") {
+		t.Errorf("Expected wrong password message but got: \n%s", response.Body.String())
+	}
+
+	// invalid e-mail address
+	request, _ = http.NewRequest("PUT", uriAlice, jsonBody("testtest", "a"))
+	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "valid e-mail address") {
+		t.Errorf("Expected invalid e-mail message but got: \n%s", response.Body.String())
+	}
+
+	// valid e-mail address
+	request, _ = http.NewRequest("PUT", uriAlice, jsonBody("testtest", "testemail@noone.com"))
+	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusOK, response.Code)
 	}
 }
 

--- a/web/account_test.go
+++ b/web/account_test.go
@@ -376,7 +376,7 @@ func TestUpdateAccountEmail(t *testing.T) {
 	if response.Code != http.StatusBadRequest {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
 	}
-	if !strings.Contains(response.Body.String(), "Wrong password") {
+	if !strings.Contains(response.Body.String(), "Invalid password") {
 		t.Errorf("Expected wrong password message but got: \n%s", response.Body.String())
 	}
 

--- a/web/reset.go
+++ b/web/reset.go
@@ -197,12 +197,17 @@ func Reset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account.SetPassword(formData.Password)
+	err = account.UpdatePassword(formData.Password)
+	if err != nil {
+		panic(err)
+	}
+
 	account.ResetPWCode.Valid = false
 	err = account.Update()
 	if err != nil {
 		panic(err)
 	}
+
 	err = account.RemoveActivationCode()
 	if err != nil {
 		panic(err)

--- a/web/reset_test.go
+++ b/web/reset_test.go
@@ -345,6 +345,9 @@ func TestReset(t *testing.T) {
 	if account.PWHash == pwHash {
 		t.Errorf("Password of Account with id '%s' has not been updated", id)
 	}
+	if !account.VerifyPassword("pw") {
+		t.Error("Password has not been properly updated")
+	}
 	if account.ResetPWCode.String != "" {
 		t.Errorf("Password reset code of Account with id '%s' has not been removed", id)
 	}

--- a/web/routes.go
+++ b/web/routes.go
@@ -57,6 +57,8 @@ func RegisterRoutes(r *mux.Router) {
 		Methods("PUT")
 	api.Handle("/accounts/{login}/password", OAuthHandler("account-write")(http.HandlerFunc(UpdateAccountPassword))).
 		Methods("PUT")
+	api.Handle("/accounts/{login}/email", OAuthHandler("account-write")(http.HandlerFunc(UpdateAccountEmail))).
+		Methods("PUT")
 	api.Handle("/accounts/{login}/keys", OAuthHandler("account-read", "account-admin")(http.HandlerFunc(ListAccountKeys))).
 		Methods("GET")
 	api.Handle("/accounts/{login}/keys", OAuthHandler("account-write")(http.HandlerFunc(CreateKey))).


### PR DESCRIPTION
An account e-mail address can only be changed via a specific API endpoint after password authentication.

Closes Issue #48 
