### PR TITLE
Persistent e-mail queue

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -29,6 +29,7 @@ const (
 	defaultGrantReqLifeTime      = 15
 	defaultUnusedAccountLifeTime = 10080
 	defaultCleanerInterval       = 15
+	defaultMailQueueInterval     = 1
 )
 
 // Default smtp settings
@@ -68,6 +69,7 @@ type ServerConfig struct {
 	GrantReqLifeTime      time.Duration
 	UnusedAccountLifeTime time.Duration
 	CleanerInterval       time.Duration
+	MailQueueInterval     time.Duration
 }
 
 var serverConfig *ServerConfig
@@ -123,6 +125,7 @@ func GetServerConfig() *ServerConfig {
 				GrantReqLifeTime      int    `yaml:"GrantReqLifeTime"`
 				UnusedAccountLifeTime int    `yaml:"UnusedAccountLifeTime"`
 				CleanerInterval       int    `yaml:"CleanerInterval"`
+				MailQueueInterval     int    `yaml:"MailQueueInterval"`
 			}
 		}{}
 		err = yaml.Unmarshal(content, config)
@@ -153,6 +156,9 @@ func GetServerConfig() *ServerConfig {
 		if config.Http.CleanerInterval == 0 {
 			config.Http.CleanerInterval = defaultCleanerInterval
 		}
+		if config.Http.MailQueueInterval == 0 {
+			config.Http.MailQueueInterval = defaultMailQueueInterval
+		}
 
 		serverConfig = &ServerConfig{
 			Host:                  config.Http.Host,
@@ -163,6 +169,7 @@ func GetServerConfig() *ServerConfig {
 			GrantReqLifeTime:      time.Duration(config.Http.GrantReqLifeTime) * time.Minute,
 			UnusedAccountLifeTime: time.Duration(config.Http.UnusedAccountLifeTime) * time.Minute,
 			CleanerInterval:       time.Duration(config.Http.CleanerInterval) * time.Minute,
+			MailQueueInterval:     time.Duration(config.Http.MailQueueInterval) * time.Minute,
 		}
 	}
 

--- a/data/data.go
+++ b/data/data.go
@@ -105,3 +105,17 @@ func EmailDispatch() {
 		}
 	}
 }
+
+// RunEmailDispatch starts an infinite loop which periodically
+// runs e-mail queue functions.
+func RunEmailDispatch() {
+	go func() {
+		t := time.NewTicker(conf.GetServerConfig().MailQueueInterval)
+		for {
+			select {
+			case <-t.C:
+				EmailDispatch()
+			}
+		}
+	}()
+}

--- a/data/data.go
+++ b/data/data.go
@@ -9,6 +9,7 @@
 package data
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -82,4 +83,25 @@ func RunCleaner() {
 			}
 		}
 	}()
+}
+
+// EmailDispatch checks e-mail queue database entries, handles the entries
+// according to the smtp mode setting and removes the entries after they successful handling.
+func EmailDispatch() {
+	emails, err := GetQueuedEmails()
+	if err != nil {
+		panic(err)
+	}
+	for _, email := range emails {
+		err = email.Send()
+		if err != nil {
+			// TODO log if an error occurs trying to send an e-mail, but continue
+			fmt.Printf("Error trying to send e-mail (Id %d): %s\n", email.Id, err.Error())
+		} else {
+			err = email.Delete()
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package data
+
+import (
+	"testing"
+
+	"github.com/G-Node/gin-auth/conf"
+)
+
+func TestEmailDispatch(t *testing.T) {
+	InitTestDb(t)
+
+	emails, err := GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) < 3 {
+		t.Error("Expected queued e-mails, but result did not match")
+	}
+
+	// There should be three database entries, one for each smtp modes.
+	// Print and skip should result in the entries being deleted, the
+	// empty mode should result in a bad username error and
+	// should therefore not be deleted.
+	username := conf.GetSmtpCredentials().Username
+	conf.GetSmtpCredentials().Username = "iDoNotExist"
+	EmailDispatch()
+	conf.GetSmtpCredentials().Username = username
+
+	emails, err = GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) != 1 {
+		t.Error("Number of db entries do not match expected result")
+	}
+}

--- a/data/email.go
+++ b/data/email.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package data
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/G-Node/gin-auth/util"
+)
+
+// Email data as stored in the database
+type Email struct {
+	Id        int
+	Mode      sql.NullString
+	Sender    string
+	Recipient util.StringSet
+	Content   []byte
+	CreatedAt time.Time
+}

--- a/data/email.go
+++ b/data/email.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/G-Node/gin-auth/util"
+	"github.com/G-Node/gin-auth/conf"
 )
 
 // Email data as stored in the database
@@ -34,4 +35,19 @@ func GetQueuedEmails() ([]Email, error) {
 	err := database.Select(&emails, q)
 
 	return emails, err
+}
+
+// Create adds a new entry to table EmailQueue
+func (e *Email) Create(to util.StringSet, content []byte) error {
+
+	const q = `INSERT INTO EmailQueue(mode, sender, recipient, content, createdat)
+	           VALUES ($1, $2, $3, $4, now())
+	           RETURNING *`
+
+	config := conf.GetSmtpCredentials()
+	mode := sql.NullString{}
+	mode.Scan(config.Mode)
+	err := database.Get(e, q, mode, config.From, to, content)
+
+	return err
 }

--- a/data/email.go
+++ b/data/email.go
@@ -51,3 +51,10 @@ func (e *Email) Create(to util.StringSet, content []byte) error {
 
 	return err
 }
+
+// Delete removes the current e-mail from table EmailQueue
+func (e *Email) Delete() error {
+	const q = `DELETE FROM EmailQueue WHERE id=$1`
+	_, err := database.Exec(q, e.Id)
+	return err
+}

--- a/data/email.go
+++ b/data/email.go
@@ -24,3 +24,14 @@ type Email struct {
 	Content   []byte
 	CreatedAt time.Time
 }
+
+// GetQueuedEmails selects all unsent e-mails from the email queue
+// database table and returns the result as a slice of Emails.
+func GetQueuedEmails() ([]Email, error) {
+	const q = `SELECT * FROM EmailQueue order by createdat`
+
+	emails := make([]Email, 0)
+	err := database.Select(&emails, q)
+
+	return emails, err
+}

--- a/data/email_test.go
+++ b/data/email_test.go
@@ -58,3 +58,29 @@ func TestEmail_Create(t *testing.T) {
 		email.Id, email.Mode.String, email.Sender, email.Recipient.Strings()[0],
 		string(email.Content), email.Content, email.CreatedAt.String())
 }
+
+func TestEmail_Delete(t *testing.T) {
+	InitTestDb(t)
+
+	emails, err := GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) < 1 {
+		t.Error("Expected queued e-mails, but result was empty")
+	}
+	num := len(emails)
+
+	err = emails[0].Delete()
+	if err != nil {
+		t.Errorf("Error trying to delete e-mail (Id %d, mode '%s'): %s",
+			emails[0].Id, emails[0].Mode.String, err.Error())
+	}
+	emails, err = GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) != num-1 {
+		t.Errorf("Number of e-mail entries should be '%d', but was '%d'", num-1, len(emails))
+	}
+}

--- a/data/email_test.go
+++ b/data/email_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package data
+
+import (
+	"testing"
+)
+
+func TestGetQueuedEmails(t *testing.T) {
+	InitTestDb(t)
+	emails, err := GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) < 1 {
+		t.Error("Expected queued e-mails, but result was empty")
+	}
+}

--- a/data/email_test.go
+++ b/data/email_test.go
@@ -9,7 +9,10 @@
 package data
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/G-Node/gin-auth/util"
 )
 
 func TestGetQueuedEmails(t *testing.T) {
@@ -21,4 +24,37 @@ func TestGetQueuedEmails(t *testing.T) {
 	if len(emails) < 1 {
 		t.Error("Expected queued e-mails, but result was empty")
 	}
+}
+
+func TestEmail_Create(t *testing.T) {
+	InitTestDb(t)
+
+	const recipient = "recipient@nowhere.com"
+	const content = "content"
+
+	emails, err := GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	num := len(emails)
+
+	email := &Email{}
+	err = email.Create(util.NewStringSet(recipient), []byte(content))
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	emails, err = GetQueuedEmails()
+	if err != nil {
+		t.Errorf("Error fetching queued e-mails: '%s'\n", err.Error())
+	}
+	if len(emails) != num+1 {
+		t.Error("Queued e-mail was not properly created")
+	}
+
+	// TODO implement create for all modes
+
+	fmt.Printf("'%d', '%s', '%s', '%s', '%s', asByte: '%s', '%s'\n",
+		email.Id, email.Mode.String, email.Sender, email.Recipient.Strings()[0],
+		string(email.Content), email.Content, email.CreatedAt.String())
 }

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	)(handler)
 
 	data.RunCleaner()
+	data.RunEmailDispatch()
 
 	server := http.Server{
 		Addr:    fmt.Sprintf("%s:%d", srvConf.Host, srvConf.Port),

--- a/resources/conf/migrations/1_initial-schema.sql
+++ b/resources/conf/migrations/1_initial-schema.sql
@@ -117,11 +117,21 @@ CREATE TABLE Sessions (
 
 CREATE INDEX ON Sessions (expires);
 
+CREATE TABLE EmailQueue (
+  id        SERIAL PRIMARY KEY ,
+  mode      VARCHAR(32) ,
+  sender    VARCHAR(512) NOT NULL ,
+  recipient VARCHAR[] NOT NULL ,
+  content   VARCHAR(4096) NOT NULL ,
+  createdAt TIMESTAMP NOT NULL
+);
+
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
 
 DROP VIEW IF EXISTS ActiveAccounts;
 
+DROP TABLE IF EXISTS EmailQueue CASCADE;
 DROP TABLE IF EXISTS Sessions CASCADE;
 DROP TABLE IF EXISTS AccessTokens CASCADE;
 DROP TABLE IF EXISTS RefreshTokens CASCADE;

--- a/resources/fixtures/testdb.sql
+++ b/resources/fixtures/testdb.sql
@@ -1,4 +1,5 @@
 -- Test fixtures to be used in tests
+DELETE FROM EmailQueue;
 DELETE FROM RefreshTokens;
 DELETE FROM AccessTokens;
 DELETE FROM Sessions;
@@ -63,3 +64,8 @@ INSERT INTO AccessTokens (token, expires, scope, clientUUID, accountUUID, create
 INSERT INTO RefreshTokens (token, scope, clientUUID, accountUUID, createdAt, updatedAt) VALUES
   ('YYPTDSVZ', '{"repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('4FKJVX3K', '{"repo-read","repo-write"}', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday');
+
+INSERT INTO EmailQueue (mode, sender, recipient, content, createdat) VALUES
+  (NULL, 'no-reply@g-node.org', '{"a@b.com"}', 'content1', now()),
+  ('print', 'no-reply@g-node.org', '{"a@b.com"}', 'content2', now()),
+  ('skip', 'no-reply@g-node.org', '{"a@b.com"}', 'content3', now());

--- a/web/account.go
+++ b/web/account.go
@@ -233,11 +233,10 @@ func UpdateAccountEmail(w http.ResponseWriter, r *http.Request) {
 	tmplFields.Body = "The e-mail address of your GIN account has been successfully changed."
 
 	content := util.MakeEmailTemplate("emailplain.txt", tmplFields)
-	disp := util.NewEmailDispatcher()
-
-	err = disp.Send([]string{cred.Email}, content.Bytes())
+	email := &data.Email{}
+	err = email.Create(util.NewStringSet(cred.Email), content.Bytes())
 	if err != nil {
-		msg := "An error occurred trying to send change e-mail address confirmation."
+		msg := "An error occurred trying to create change e-mail address confirmation."
 		PrintErrorJSON(w, r, msg, http.StatusInternalServerError)
 		return
 	}

--- a/web/account_test.go
+++ b/web/account_test.go
@@ -381,6 +381,8 @@ func TestUpdateAccountEmail(t *testing.T) {
 	}
 
 	// invalid e-mail address
+	emails, _ := data.GetQueuedEmails()
+	num := len(emails)
 	request, _ = http.NewRequest("PUT", uriAlice, jsonBody("testtest", "a"))
 	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
 	response = httptest.NewRecorder()
@@ -392,8 +394,13 @@ func TestUpdateAccountEmail(t *testing.T) {
 	if !strings.Contains(response.Body.String(), "valid e-mail address") {
 		t.Errorf("Expected invalid e-mail message but got: \n%s", response.Body.String())
 	}
+	emails, _ = data.GetQueuedEmails()
+	if len(emails) != num {
+		t.Errorf("Expected e-mail queue to contain '%d' entries but had '%d'", num, len(emails))
+	}
 
 	// valid e-mail address
+	num = len(emails)
 	request, _ = http.NewRequest("PUT", uriAlice, jsonBody("testtest", "testemail@noone.com"))
 	request.Header.Set("Authorization", "Bearer "+accessTokenAlice)
 	response = httptest.NewRecorder()
@@ -401,6 +408,10 @@ func TestUpdateAccountEmail(t *testing.T) {
 
 	if response.Code != http.StatusOK {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusOK, response.Code)
+	}
+	emails, _ = data.GetQueuedEmails()
+	if len(emails) <= num {
+		t.Errorf("Expected e-mail queue to contain '%d' entries but had '%d'", num, len(emails))
 	}
 }
 

--- a/web/registration.go
+++ b/web/registration.go
@@ -162,9 +162,8 @@ func (rh *registration) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tmplFields.Code = account.ActivationCode.String
 
 	content := util.MakeEmailTemplate("emailactivate.txt", tmplFields)
-	disp := util.NewEmailDispatcher()
-
-	err = disp.Send([]string{account.Email}, content.Bytes())
+	email := &data.Email{}
+	err = email.Create(util.NewStringSet(account.Email), content.Bytes())
 	if err != nil {
 		msg := "An error occurred trying to send registration e-mail. Please contact an administrator."
 		PrintErrorHTML(w, r, msg, http.StatusInternalServerError)

--- a/web/reset.go
+++ b/web/reset.go
@@ -89,9 +89,8 @@ func ResetInit(w http.ResponseWriter, r *http.Request) {
 	tmplFields.Code = account.ResetPWCode.String
 
 	content := util.MakeEmailTemplate("emailreset.txt", tmplFields)
-	disp := util.NewEmailDispatcher()
-
-	err = disp.Send([]string{account.Email}, content.Bytes())
+	email := &data.Email{}
+	err = email.Create(util.NewStringSet(account.Email), content.Bytes())
 	if err != nil {
 		msg := "An error occurred trying to send password reset e-mail. Please try again later."
 		PrintErrorHTML(w, r, msg, http.StatusInternalServerError)


### PR DESCRIPTION
All e-mails are first stored in the database. A goroutine dispatches new e-mails stored in the database every minute. Whether an e-mail is actually sent, printed to the commandline or skipped depends on the config setting at the time the e-mail was stored in the database.

Closes issue #63 
