### PR TITLE
Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,5 @@ _testmain.go
 # Logfile
 gin-auth*.log*
 
-# My playground
-playground.go
-
 # Temp
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ _testmain.go
 *.iml
 .idea
 
+# Logfile
+gin-auth*.log*
+
 # My playground
 playground.go
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
  - go get github.com/gorilla/handlers
  - go get github.com/docopt/docopt-go
  - go get github.com/dchest/captcha
+ - go get github.com/NYTimes/logrotate
+ - go get github.com/Sirupsen/logrus
 
 before_script:
  - psql -c "CREATE ROLE test WITH LOGIN PASSWORD 'test';" -U postgres

--- a/conf/log.go
+++ b/conf/log.go
@@ -7,3 +7,17 @@
 // LICENSE file in the root of the Project.
 
 package conf
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+var logEnv *LogEnv
+
+// Logging environment with error and access log and a function to
+// defer closing any associated files.
+type LogEnv struct {
+	Err    *logrus.Logger
+	Access *logrus.Logger
+	Close  func()
+}

--- a/conf/log.go
+++ b/conf/log.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package conf

--- a/conf/log.go
+++ b/conf/log.go
@@ -18,8 +18,8 @@ import (
 
 var logEnv *LogEnv
 
-// Logging environment with error and access log and a function to
-// defer closing any associated files.
+// LogEnv provides the logging environment with error and access log
+// and a function to defer closing any associated files.
 type LogEnv struct {
 	Err    *logrus.Logger
 	Access *logrus.Logger
@@ -33,8 +33,8 @@ type LogEnv struct {
 // Log files are opened using a logrotate compatible library.
 func InitLogEnv() {
 
-	accFile := "gin-auth.access.log"
-	errFile := "gin-auth.err.log"
+	accFile := GetLogLocation().Access
+	errFile := GetLogLocation().Error
 
 	logEnv = &LogEnv{
 		Access: logrus.New(),

--- a/conf/log.go
+++ b/conf/log.go
@@ -72,3 +72,10 @@ func InitLogEnv() {
 	logEnv.Err.Error("Error logging started")
 }
 
+// GetLogEnv initializes the global logger if required and returns it.
+func GetLogEnv() *LogEnv {
+	if logEnv == nil {
+		InitLogEnv()
+	}
+	return logEnv
+}

--- a/conf/log.go
+++ b/conf/log.go
@@ -9,6 +9,10 @@
 package conf
 
 import (
+	"io"
+	"os"
+
+	"github.com/NYTimes/logrotate"
 	"github.com/Sirupsen/logrus"
 )
 
@@ -21,3 +25,50 @@ type LogEnv struct {
 	Access *logrus.Logger
 	Close  func()
 }
+
+// InitLogEnv initializes loggers for access and error.
+// Default access log directs to Stdout, default error log
+// directs to Stderr. If log files are provided, the output
+// will be directed to the respective default and the log file.
+// Log files are opened using a logrotate compatible library.
+func InitLogEnv() {
+
+	accFile := "gin-auth.access.log"
+	errFile := "gin-auth.err.log"
+
+	logEnv = &LogEnv{
+		Access: logrus.New(),
+		Err:    logrus.New(),
+	}
+	logEnv.Access.Out = os.Stdout
+
+	fs := make([]*logrotate.File, 0, 2)
+
+	if accFile != "" {
+		af, err := logrotate.NewFile(accFile)
+		if err != nil {
+			panic(err)
+		}
+		logEnv.Access.Out = io.MultiWriter(os.Stdout, af)
+		fs = append(fs, af)
+	}
+
+	if errFile != "" {
+		ef, err := logrotate.NewFile(errFile)
+		if err != nil {
+			panic(err)
+		}
+		logEnv.Err.Out = io.MultiWriter(os.Stderr, ef)
+		fs = append(fs, ef)
+	}
+
+	logEnv.Close = func() {
+		for _, f := range fs {
+			f.Close()
+		}
+	}
+
+	logEnv.Access.Info("Access logging started")
+	logEnv.Err.Error("Error logging started")
+}
+

--- a/data/data.go
+++ b/data/data.go
@@ -9,7 +9,6 @@
 package data
 
 import (
-	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -73,7 +72,6 @@ func RemoveStaleAccounts() {
 // periodically executes database cleanup functions.
 func RunCleaner() {
 	go func() {
-		// TODO add log entry once logging is implemented
 		t := time.NewTicker(conf.GetServerConfig().CleanerInterval)
 		for {
 			select {
@@ -95,8 +93,8 @@ func EmailDispatch() {
 	for _, email := range emails {
 		err = email.Send()
 		if err != nil {
-			// TODO log if an error occurs trying to send an e-mail, but continue
-			fmt.Printf("Error trying to send e-mail (Id %d): %s\n", email.Id, err.Error())
+			conf.GetLogEnv().Err.
+				Errorf("Error trying to send e-mail (Id %d): %s\n", email.Id, err.Error())
 		} else {
 			err = email.Delete()
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/G-Node/gin-auth/conf"
 	"github.com/G-Node/gin-auth/data"
+	"github.com/G-Node/gin-auth/util"
 	"github.com/G-Node/gin-auth/web"
 	"github.com/docopt/docopt-go"
 	"github.com/gorilla/handlers"
@@ -58,7 +59,7 @@ func main() {
 
 	web.RegisterRoutes(router)
 
-	handler := handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(router)
+	handler := util.RecoveryHandler(router, logEnv.Err, true)
 	handler = handlers.LoggingHandler(logEnv.Access.Out, handler)
 	handler = handlers.CORS(
 		handlers.AllowedHeaders([]string{"Accept", "Content-Type", "Authorization"}),

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/G-Node/gin-auth/conf"
 	"github.com/G-Node/gin-auth/data"
@@ -43,6 +42,10 @@ func main() {
 		conf.SetResourcesPath(res.(string))
 	}
 
+	// Initialize logging and make sure log files will be closed.
+	logEnv := conf.GetLogEnv()
+	defer logEnv.Close()
+
 	srvConf := conf.GetServerConfig()
 	conf.SmtpCheck()
 
@@ -56,7 +59,7 @@ func main() {
 	web.RegisterRoutes(router)
 
 	handler := handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(router)
-	handler = handlers.LoggingHandler(os.Stdout, handler)
+	handler = handlers.LoggingHandler(logEnv.Access.Out, handler)
 	handler = handlers.CORS(
 		handlers.AllowedHeaders([]string{"Accept", "Content-Type", "Authorization"}),
 		handlers.AllowedOrigins([]string{"*"}),

--- a/resources/conf/server.yml
+++ b/resources/conf/server.yml
@@ -12,3 +12,6 @@ smtp:
 #   Print will write the content of any e-mail to the commandline / log
 #   Skip will skip over any e-mail sending process
   Mode: print
+log:
+  Access: gin-auth.access.log
+  Error: gin-auth.error.log

--- a/util/recovery.go
+++ b/util/recovery.go
@@ -7,3 +7,29 @@
 // LICENSE file in the root of the Project.
 
 package util
+
+import (
+	"net/http"
+)
+
+type recoveryHandler struct {
+	handler http.Handler
+}
+
+// RecoveryHandler recovers from a panic, writes an HTTP InternalServerError,
+// and continues to the next handler.
+func RecoveryHandler(h http.Handler) http.Handler {
+	return &recoveryHandler{
+		handler: h,
+	}
+}
+
+func (h recoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}()
+
+	h.handler.ServeHTTP(w, req)
+}

--- a/util/recovery.go
+++ b/util/recovery.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package util


### PR DESCRIPTION
- Adds logging to the server.
- If nothing is specified, log messages will be written to stdout and stderr by default.
- Logfiles for access and error logs can be provided in the server.yml file.
- If any file is specified, logs will be written to the logfile as well as the appropriate stdout and stderr.
- Further adds a custom recovery handler to register panic handling and error logging to the server.
