### PR TITLE
Support NoAuth and PlainAuth

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -273,6 +273,19 @@ func GetSmtpCredentials() *SmtpCredentials {
 	return smtpCred
 }
 
+// NoAuth is a minimal implementation of the smtp.Auth interface.
+type NoAuth struct{}
+
+// Start always returns proto = "" to indicate, that the authentication can be skipped.
+func (a *NoAuth) Start(server *smtp.ServerInfo) (proto string, toServer []byte, err error) {
+	return "", nil, nil
+}
+
+// Next always returns toServer = nil to indicate, that the authentication can be skipped.
+func (a *NoAuth) Next(fromServer []byte, more bool) (toServer []byte, err error) {
+	return nil, nil
+}
+
 // SmtpCheck tests whether a connection to the specified smtp server can be established
 // with the provided credentials and will panic if it cannot.
 func SmtpCheck() error {

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -12,13 +12,18 @@ import (
 	"testing"
 )
 
+const httpHost = "localhost"
+const httpPort = 8081
+const smtpHost = "localhost"
+const smtpPort = 25
+
 func TestGetServerConfig(t *testing.T) {
 	config := GetServerConfig()
-	if config.Host != "localhost" {
-		t.Error("Host expected to be 'localhost'")
+	if config.Host != httpHost {
+		t.Errorf("Host expected to be '%s'\n", httpHost)
 	}
-	if config.Port != 8081 {
-		t.Error("Port expected to be '8081'")
+	if config.Port != httpPort {
+		t.Errorf("Port expected to be '%d'\n", httpPort)
 	}
 	if config.BaseURL != "http://localhost:8081" {
 		t.Error("BaseURL expected to be 'http://localhost:8081'")
@@ -34,8 +39,11 @@ func TestGetDbConfig(t *testing.T) {
 
 func TestGetSmtpCredentials(t *testing.T) {
 	creds := GetSmtpCredentials()
-	if creds.Port != 587 {
-		t.Errorf("Port expected to be 587 but was '%d'", creds.Port)
+	if creds.Host != smtpHost {
+		t.Errorf("Host expected to be '%s'\n", smtpHost)
+	}
+	if creds.Port != smtpPort {
+		t.Errorf("Port expected to be '%d' but was '%d'\n", smtpPort, creds.Port)
 	}
 }
 

--- a/resources/conf/server.yml
+++ b/resources/conf/server.yml
@@ -6,8 +6,8 @@ smtp:
   From: no-reply@g-node.org
   Username:
   Password:
-  Host: mx1.g-node.org
-  Port: 587
+  Host: localhost
+  Port: 25
 # Supported values of Mode are: print and skip; in any other case e-mails will be sent.
 #   Print will write the content of any e-mail to the commandline / log
 #   Skip will skip over any e-mail sending process


### PR DESCRIPTION
Refactor Send E-Mail and SmtpCheck so that both no authentication as well as plain authentication is supported.
- In case of empty username and password no authentication is assumed.
- In any other case plain authentication is assumed.
- Plain authentication has been successfully tested locally.
- No authentication has been successfully tested on the server.
- Adjusting Server SMTP settings.
- Updating tests.
