### PR TITLE
Enable use of non resources/conf configuration files on start up

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -43,7 +43,6 @@ var (
 	serverConfigFile  = filepath.Join("conf", "server.yml")
 	dbConfigFile      = filepath.Join("conf", "dbconf.yml")
 	clientsConfigFile = filepath.Join("conf", "clients.yml")
-	staticFilesDir    = filepath.Join("static")
 )
 
 func init() {
@@ -222,11 +221,6 @@ func GetResourceFile(p ...string) string {
 // GetClientsConfigFile returns the path to the clients configuration file.
 func GetClientsConfigFile() string {
 	return filepath.Join(resourcesPath, clientsConfigFile)
-}
-
-// GetStaticFilesDir returns the path to the static files directory.
-func GetStaticFilesDir() string {
-	return filepath.Join(resourcesPath, staticFilesDir)
 }
 
 // GetSmtpCredentials loads the smtp access information from a yaml file when called the first time.

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -40,15 +40,17 @@ const (
 
 var (
 	resourcesPath     string
-	serverConfigFile  = filepath.Join("conf", "server.yml")
-	dbConfigFile      = filepath.Join("conf", "dbconf.yml")
-	clientsConfigFile = filepath.Join("conf", "clients.yml")
+	configPath        string
+	serverConfigFile  = "server.yml"
+	dbConfigFile      = "dbconf.yml"
+	clientsConfigFile = "clients.yml"
 )
 
 func init() {
 	basePath := os.Getenv("GOPATH")
 	if basePath != "" {
 		resourcesPath = filepath.Join(basePath, "src", "github.com", "G-Node", "gin-auth", "resources")
+		configPath = filepath.Join(resourcesPath, "conf")
 	}
 }
 
@@ -57,6 +59,11 @@ func init() {
 // package are used.
 func SetResourcesPath(res string) {
 	resourcesPath = res
+}
+
+// SetConfigPath sets the resource path to the specified location.
+func SetConfigPath(config string) {
+	configPath = config
 }
 
 // ServerConfig provides several general configuration parameters for gin-auth
@@ -119,7 +126,7 @@ func GetServerConfig() *ServerConfig {
 	defer serverConfigLock.Unlock()
 
 	if serverConfig == nil {
-		content, err := ioutil.ReadFile(filepath.Join(resourcesPath, serverConfigFile))
+		content, err := ioutil.ReadFile(filepath.Join(configPath, serverConfigFile))
 		if err != nil {
 			panic(err)
 		}
@@ -192,7 +199,7 @@ func GetDbConfig() *DbConfig {
 	defer dbConfigLock.Unlock()
 
 	if dbConfig == nil {
-		content, err := ioutil.ReadFile(filepath.Join(resourcesPath, dbConfigFile))
+		content, err := ioutil.ReadFile(filepath.Join(configPath, dbConfigFile))
 		if err != nil {
 			panic(err)
 		}
@@ -220,7 +227,7 @@ func GetResourceFile(p ...string) string {
 
 // GetClientsConfigFile returns the path to the clients configuration file.
 func GetClientsConfigFile() string {
-	return filepath.Join(resourcesPath, clientsConfigFile)
+	return filepath.Join(configPath, clientsConfigFile)
 }
 
 // GetSmtpCredentials loads the smtp access information from a yaml file when called the first time.
@@ -230,7 +237,7 @@ func GetSmtpCredentials() *SmtpCredentials {
 	defer smtpCredLock.Unlock()
 
 	if smtpCred == nil {
-		content, err := ioutil.ReadFile(filepath.Join(resourcesPath, serverConfigFile))
+		content, err := ioutil.ReadFile(filepath.Join(configPath, serverConfigFile))
 		if err != nil {
 			panic(err)
 		}
@@ -329,7 +336,7 @@ func GetLogLocation() *LogLocations {
 	defer logLocLock.Unlock()
 
 	if logLoc == nil {
-		fc, err := ioutil.ReadFile(filepath.Join(resourcesPath, serverConfigFile))
+		fc, err := ioutil.ReadFile(filepath.Join(configPath, serverConfigFile))
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -26,14 +26,16 @@ func versionString() string {
 const doc = `G-Node Infrastructure Authentication Provider
 
 Usage:
-  gin-auth [--res <dir>]
+  gin-auth [--res <dir>] [--conf <dir>]
   gin-auth -h | --help
   gin-auth --version
 
 Options:
-  --res <dir>     Path to the resources directory where configuration files,
-                  templates and static files are located. By default gin-auth
+  --res <dir>     Path to the resources directory where templates
+                  and static files are located. By default gin-auth
                   will use GOPATH to find the directory.
+  --conf <dir>    Path to the configuration files directory. By default
+                  gin-auth will use the resources/conf directory.
   -h --help       Show this screen.
   --version       Print gin-auth version`
 

--- a/main.go
+++ b/main.go
@@ -45,6 +45,10 @@ func main() {
 		conf.SetResourcesPath(res.(string))
 	}
 
+	if config, ok := args["--conf"]; ok && config != nil {
+		conf.SetConfigPath(config.(string))
+	}
+
 	// Initialize logging and make sure log files will be closed.
 	logEnv := conf.GetLogEnv()
 	defer logEnv.Close()


### PR DESCRIPTION
Resolves issue #86.
- adds conf command line option
- disentangles usage of config folder and resources folder
