### PR TITLE
Account login and test execution fixes

### DIFF
--- a/data/account.go
+++ b/data/account.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -313,6 +314,11 @@ func (acc *Account) Validate() *util.ValidationError {
 	if acc.Login == "" {
 		valErr.FieldErrors["login"] = "Please add login"
 	}
+	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
+	if !re.MatchString(acc.Login) {
+		valErr.FieldErrors["login"] = "Please use only the following characters: 'a-zA-Z0-9-_'"
+	}
+
 	if !(len(acc.Email) > 2) || !strings.Contains(acc.Email, "@") {
 		valErr.FieldErrors["email"] = "Please add a valid e-mail address"
 	}

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -543,7 +543,22 @@ func TestValidate(t *testing.T) {
 		t.Errorf("Expected existing login error, but got: '%s'", valErr.FieldErrors["login"])
 	}
 
+	// Test missing login
+	account.Login = ""
+	valErr = account.Validate()
+	if valErr.FieldErrors["login"] != "Please add login" {
+		t.Errorf("Expected missing login error, but got: '%s'", valErr.FieldErrors["login"])
+	}
+
+	// Test login with invalid characters
+	account.Login = "alice/"
+	valErr = account.Validate()
+	if !strings.Contains(valErr.FieldErrors["login"], "Please use only the following characters: ") {
+		t.Errorf("Expected invalid characters error, but got: '%s'\n", valErr.FieldErrors["login"])
+	}
+
 	// Test existing email
+	account.Login = "no-one_1234567890_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	valErr = account.Validate()
 	if valErr.FieldErrors["email"] != "Please choose a different email address" {
 		t.Errorf("Expected existing email error, but got: '%s'", valErr.FieldErrors["email"])
@@ -561,15 +576,7 @@ func TestValidate(t *testing.T) {
 		t.Errorf("Expected invalid email error, but got: '%s'", valErr.FieldErrors["email"])
 	}
 
-	// Test missing login
-	account.Login = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["login"] != "Please add login" {
-		t.Errorf("Expected missing login error, but got: '%s'", valErr.FieldErrors["login"])
-	}
-
 	// Test missing email
-	account.Login = "noone"
 	account.Email = ""
 	valErr = account.Validate()
 	if valErr.FieldErrors["email"] != "Please add a valid e-mail address" {

--- a/data/data.go
+++ b/data/data.go
@@ -10,6 +10,7 @@ package data
 
 import (
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,9 @@ func InitDb(config *conf.DbConfig) {
 // InitTestDb initializes a database for testing purpose.
 func InitTestDb(t *testing.T) {
 	config := conf.GetDbConfig()
+	if !strings.Contains(config.Open, "user=test") {
+		t.Fatal("Prohibit running tests outside a test environment.")
+	}
 	InitDb(config)
 
 	fixtures, err := ioutil.ReadFile(conf.GetResourceFile("fixtures", "testdb.sql"))


### PR DESCRIPTION
- Add regular expression check to account validation, to allow only characters "a-zA-Z0-9-_" with login. Fixes issue #87.
- Fail all tests using the database, if the connection to the DB is done by any other user than 'test'. Fixes issue #89.

The second point quick fixes, that the DB on the production machine would be nuked, if tests are executed there. Thoughts on the issue are appreciated!
