### PR TITLE
Database changes and additions

### DIFF
--- a/data/client.go
+++ b/data/client.go
@@ -212,10 +212,12 @@ func (client *Client) Approve(accountUUID string, scope util.StringSet) (err err
 }
 
 // CreateGrantRequest check whether response type, redirect URI and scope are valid and creates a new
-// grant request for this client.
+// grant request for this client. Grant types are defined by RFC6749 "OAuth 2.0 Authorization Framework"
+// Supported grant types are: "code" (authorization code), "token" (implicit request),
+// "owner" (resource owner password credentials), "client" (client credentials)
 func (client *Client) CreateGrantRequest(responseType, redirectURI, state string, scope util.StringSet) (*GrantRequest, error) {
-	if !(responseType == "code" || responseType == "token") {
-		return nil, errors.New("Response type expected to be 'code' or 'token'")
+	if !(responseType == "code" || responseType == "token" || responseType == "owner" || responseType == "client") {
+		return nil, errors.New("Response type expected to be one of the following: 'code', 'token', 'owner', 'client'")
 	}
 	if !client.RedirectURIs.Contains(redirectURI) {
 		return nil, fmt.Errorf("Redirect URI invalid: '%s'", redirectURI)

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,8 +38,9 @@ for dep in "$EXTDEPS"; do
     sudo -u deploy -E GOPATH=$GOPATH /opt/go/bin/go get -v $dep
 done
 
-echo "Update dbconfig file for goose"
+echo "Update server specific config files for goose"
 cp /opt/deploy/service_conf/gin-auth/dbconf.yml /opt/deploy/gin-auth/resources/conf
+cp /opt/deploy/service_conf/gin-auth/2_initial_client_data.sql /opt/deploy/gin-auth/resources/conf/migrations
 
 echo "Update database scheme to the latest version"
 goose -path /opt/deploy/gin-auth/resources/conf up
@@ -51,7 +52,8 @@ echo "Restarting gin-auth"
 sudo systemctl --user daemon-reload
 sudo systemctl --user restart ginauth.service
 
-echo "Reset dbconfig file"
+echo "Reset server specific config files"
 sudo -u deploy git checkout resources/conf/dbconf.yml
+sudo -u deploy git checkout resources/conf/migrations/2_initial_client_data.sql
 
 echo -e "${CAOK}Done${CNOC}."

--- a/resources/conf/migrations/1_initial-schema.sql
+++ b/resources/conf/migrations/1_initial-schema.sql
@@ -76,7 +76,7 @@ CREATE TABLE ClientApprovals (
 
 CREATE TABLE GrantRequests (
   token             VARCHAR(512) PRIMARY KEY ,       -- the grant request id
-  grantType         VARCHAR(10) NOT NULL CHECK (grantType = 'code' OR grantType = 'token'),
+  grantType         VARCHAR(10) NOT NULL ,
   state             VARCHAR(512) NOT NULL ,
   code              VARCHAR(512) ,
   scopeRequested    VARCHAR[] NOT NULL ,

--- a/resources/conf/migrations/2_initial_client_data.sql
+++ b/resources/conf/migrations/2_initial_client_data.sql
@@ -1,0 +1,32 @@
+-- Copyright (c) 2016, German Neuroinformatics Node (G-Node),
+--                           Michael Sonntag <dev@g-node.org>
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted under the terms of the BSD License. See
+-- LICENSE file in the root of the Project.
+
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+INSERT INTO Clients (uuid, name, secret, scopewhitelist, scopeblacklist, redirecturis, createdat, updatedat) VALUES
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'gin', 'secret', '{"account-create"}', '{"account-admin"}',
+            '{"https://localhost:8081/login","http://localhost:8080/"}', now(), now()),
+  ('177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'wb', 'secret', '{"account-read","repo-read"}',
+            '{"account-admin"}', '{"https://localhost:8081/login"}', now(), now());
+
+INSERT INTO ClientScopeProvided (clientuuid, name, description) VALUES
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-create', 'Create an account') ,
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-read', 'Read access to your account data') ,
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-write', 'Write access to your account data') ,
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-admin', 'Admin access to all account data') ,
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'repo-read', 'Read access to your repositories and repositories shared with you') ,
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'repo-write', 'Write access to your repositories and repositories you have write access to');
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DELETE FROM ClientScopeProvided;
+DELETE FROM Clients;

--- a/resources/fixtures/testdb.sql
+++ b/resources/fixtures/testdb.sql
@@ -35,10 +35,11 @@ INSERT INTO SSHKeys (fingerprint, accountUUID, description, temporary, key, crea
   ('dgU2JX3eCYur5xbKhFQ+jEACSurCwtRaG+Qn6SYq7lE', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'Bobs new temporary key', true, 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKHfQ67plrnKU5ua2JP6zTYZWiN23H26paJ4M/7r1/m9Ct8a3Oy5qK0LGmwj+nSInOX5U5AmQSnAfqnVcXG1QWP/GEvz7fxm+99ZU00P+Pti1AenmiK69qxvP7dMC3KJbwe6haEgVHNbDy3Uj1lW+cIH+FUkpuoLr5B6tCrXAUD+ZJrSAR3VlYMbAQ5W4ElU3Oh1gruacINCy3B83D3PVSumdgnPopYQdcFSVFv22fHGal4iw1T/M0Xfe7iQevLaEa/F+BwX8IAqNJb3mA+1JQbF0Vkfo+qxMtK3OUK0hZIYheH9H1OIl53RZ18jck0IWBgyo8chegSMoNtL3gzA6p bar@foo', now(), now());
 
 INSERT INTO Clients (uuid, name, secret, scopeWhitelist, scopeBlacklist, redirectURIs, createdAt, updatedAt) VALUES
-  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'gin', 'secret', '{}','{"account-admin"}','{"https://localhost:8081/login"}', now(), now()),
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'gin', 'secret', '{"account-create"}','{"account-admin"}','{"https://localhost:8081/login","http://localhost:8080/"}', now(), now()),
   ('177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'wb', 'secret', '{"account-read","repo-read"}','{"account-admin"}','{"https://localhost:8081/login"}', now(), now());
 
 INSERT INTO ClientScopeProvided (clientuuid, name, description) VALUES
+  ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-create', 'Create an account'),
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-read', 'Read access to your account data'),
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-write', 'Write access to your account data'),
   ('8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'account-admin', 'Admin access to all account data'),


### PR DESCRIPTION
Changes to the database schema and the additional client data script are prerequisites to issue #107.

- removes `grantType` value check from database table `GrantRequests`.
- adds additional checks for grant types `owner` and `client` to `CreateGrantRequest`.
- adds goose migration script to add `Clients` and `ClientScopeProvided` initial data.
- adds additional `account-create` client scope in the process.
- adds additional client redirection URI.
- updates test database setup to accommodate changes above.
- updates deploy script to accommodate different `Clients` server-side database entries.
