### PR TITLE
GrantRequest when registering an account

### DIFF
--- a/data/client.go
+++ b/data/client.go
@@ -228,6 +228,9 @@ func (client *Client) CreateGrantRequest(responseType, redirectURI, state string
 	if scope.Intersect(client.ScopeBlacklist).Len() > 0 {
 		return nil, errors.New("Blacklisted scope")
 	}
+	if state == "" {
+		return nil, errors.New("Missing client state")
+	}
 
 	request := &GrantRequest{
 		GrantType:      responseType,

--- a/data/grant_request_test.go
+++ b/data/grant_request_test.go
@@ -29,8 +29,8 @@ func TestListGrantRequests(t *testing.T) {
 	InitTestDb(t)
 
 	requests := ListGrantRequests()
-	if len(requests) != 3 {
-		t.Errorf("Exactly 3 grant requests expected in list but was %d", len(requests))
+	if len(requests) != 4 {
+		t.Errorf("Exactly 4 grant requests expected in list but was %d", len(requests))
 	}
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -39,18 +39,18 @@ for dep in "$EXTDEPS"; do
 done
 
 echo "Update server specific config files for goose"
-cp /opt/deploy/service_conf/gin-auth/dbconf.yml /opt/deploy/gin-auth/resources/conf
-cp /opt/deploy/service_conf/gin-auth/2_initial_client_data.sql /opt/deploy/gin-auth/resources/conf/migrations
+sudo -u deploy cp /opt/deploy/service_conf/gin-auth/dbconf.yml /opt/deploy/gin-auth/resources/conf
+sudo -u deploy cp /opt/deploy/service_conf/gin-auth/2_initial_client_data.sql /opt/deploy/gin-auth/resources/conf/migrations
 
 echo "Update database scheme to the latest version"
-goose -path /opt/deploy/gin-auth/resources/conf up
+sudo -u deploy -E GOPATH=$GOPATH $GOPATH/bin/goose -path /opt/deploy/gin-auth/resources/conf up
 
 echo "Installing gin-auth"
 sudo -u deploy -E GOPATH=$GOPATH /opt/go/bin/go install
 
 echo "Restarting gin-auth"
-sudo systemctl --user daemon-reload
-sudo systemctl --user restart ginauth.service
+sudo systemctl daemon-reload
+sudo systemctl restart ginauth.service
 
 echo "Reset server specific config files"
 sudo -u deploy git checkout resources/conf/dbconf.yml

--- a/resources/fixtures/testdb.sql
+++ b/resources/fixtures/testdb.sql
@@ -54,7 +54,8 @@ INSERT INTO GrantRequests (token, grantType, state, code, scopeRequested, redire
   ('U7JIKKYI', 'code', 'OCQYDRYW', 'HGZQP6WE','{"repo-read","repo-write"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('QH92T99D', 'code', 'HD58GHV9', NULL ,'{"account-read","repo-read"}', 'https://localhost:8081/login', '177c56a4-57b4-4baf-a1a7-04f3d8e5b276', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),
   ('B4LIMIMB', 'code', '6Y4UTL24', 'C52KLSIZ','{"repo-read","repo-write"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', now(), now()),
-  ('AGTBAI3D', 'code', 'GBNAM23L', 'KWANG2G4','{"account-read"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday');
+  ('AGTBAI3D', 'code', 'GBNAM23L', 'KWANG2G4','{"account-read"}', 'https://localhost:8081/login', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', '51f5ac36-d332-4889-8023-6e033fcd8e17', 'yesterday', 'yesterday'),
+  ('QPJ64HK0', 'client', 'AHZ6DK8F', '0LA7T4EO','{"account-create"}', 'http://localhost:8080/', '8b14d6bb-cae7-4163-bbd1-f3be46e43e31', NULL, now(), now());
 
 INSERT INTO Sessions (token, expires, accountUUID, createdAt, updatedAt) VALUES
   ('DNM5RS3C', 'tomorrow', 'bf431618-f696-4dca-a95d-882618ce4ef9', now(), now()),

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -73,7 +73,7 @@
             </label>
         </div>
     </div>
-
+    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
 
     <h4>Affiliation</h4>
     <hr>

--- a/web/commons.go
+++ b/web/commons.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package web
+

--- a/web/commons.go
+++ b/web/commons.go
@@ -8,3 +8,47 @@
 
 package web
 
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/G-Node/gin-auth/data"
+	"github.com/G-Node/gin-auth/util"
+)
+
+// createGrantRequest creates a Grant Request for a client and redirects to a forwarding URI.
+func createGrantRequest(w http.ResponseWriter, r *http.Request, forwardURI string) {
+	param := &struct {
+		ResponseType string
+		ClientId     string
+		RedirectURI  string
+		State        string
+		Scope        string
+	}{}
+
+	err := util.ReadQueryIntoStruct(r, param, false)
+	if err != nil {
+		PrintErrorHTML(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	client, ok := data.GetClientByName(param.ClientId)
+	if !ok {
+		PrintErrorHTML(w, r, fmt.Sprintf("Client '%s' does not exist", param.ClientId), http.StatusBadRequest)
+		return
+	}
+
+	scope := util.NewStringSet(strings.Split(param.Scope, " ")...)
+	request, err := client.CreateGrantRequest(param.ResponseType, param.RedirectURI, param.State, scope)
+	if err != nil {
+		PrintErrorHTML(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	queryVals := &url.Values{}
+	queryVals.Add("request_id", request.Token)
+	w.Header().Add("Cache-Control", "no-store")
+	http.Redirect(w, r, forwardURI+"?"+queryVals.Encode(), http.StatusFound)
+}

--- a/web/commons_test.go
+++ b/web/commons_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+package web
+

--- a/web/commons_test.go
+++ b/web/commons_test.go
@@ -8,3 +8,125 @@
 
 package web
 
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/G-Node/gin-auth/data"
+	"github.com/G-Node/gin-auth/util"
+)
+
+func TestCreateGrantRequest(t *testing.T) {
+	defer util.FailOnPanic(t)
+	data.InitTestDb(t)
+
+	const invalidClientId = "iDoNotExist"
+	const invalidScope = "iDoNotExist"
+
+	const validResponseType = "code"
+	const validClientId = "gin"
+	const validRedirectURI = "http://localhost:8080/"
+	const validState = "clientState"
+	const validScope = "account-create"
+
+	const forwardURI = "/forward/uri"
+
+	queryVals := &url.Values{}
+	queryVals.Add("response_type", validResponseType)
+	queryVals.Add("client_id", validClientId)
+	queryVals.Add("redirect_uri", validRedirectURI)
+	queryVals.Add("state", validState)
+	queryVals.Add("scope", validScope)
+
+	// Ensure fail if any of the fields is missing
+	// Test missing response type
+	queryVals.Del("response_type")
+	request, _ := http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response := httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test missing client id
+	queryVals.Add("response_type", validResponseType)
+	queryVals.Del("client_id")
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test missing redirect uri
+	queryVals.Add("client_id", validClientId)
+	queryVals.Del("redirect_uri")
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test missing state
+	queryVals.Add("redirect_uri", validRedirectURI)
+	queryVals.Del("state")
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test missing Scope
+	queryVals.Add("state", validState)
+	queryVals.Del("scope")
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test invalid client id
+	queryVals.Add("scope", validScope)
+	queryVals.Set("client_id", invalidClientId)
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test create fail using invalid scope
+	queryVals.Set("client_id", validClientId)
+	queryVals.Set("scope", invalidScope)
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
+	// Test correct redirect and URI query after create
+	queryVals.Set("scope", validScope)
+	request, _ = http.NewRequest("GET", "/root?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	createGrantRequest(response, request, forwardURI)
+	if response.Code != http.StatusFound {
+		t.Errorf("Expected code %d but got %d\n", http.StatusFound, response.Code)
+	}
+	location, err := response.Result().Location()
+	if err != nil {
+		t.Error(err)
+	}
+	if location.Path != forwardURI {
+		t.Errorf("Expected forward uri to be %q but was %q\n", forwardURI, location.Path)
+	}
+	if !strings.Contains(location.RawQuery, "request_id=") {
+		t.Errorf("Request token is missing from redirect uri query: %q\n", location.RawQuery)
+	}
+}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -118,37 +118,9 @@ func (o oauth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Authorize handles the beginning of an OAuth grant request following the schema
-// of 'implicit' or 'code' grant types.
+// of any of the 'implicit', 'code', 'owner' or 'client' grant types.
 func Authorize(w http.ResponseWriter, r *http.Request) {
-	param := &struct {
-		ResponseType string
-		ClientId     string
-		RedirectURI  string
-		State        string
-		Scope        string
-	}{}
-
-	err := util.ReadQueryIntoStruct(r, param, false)
-	if err != nil {
-		PrintErrorHTML(w, r, err, http.StatusBadRequest)
-		return
-	}
-
-	client, ok := data.GetClientByName(param.ClientId)
-	if !ok {
-		PrintErrorHTML(w, r, fmt.Sprintf("Client '%s' does not exist", param.ClientId), http.StatusBadRequest)
-		return
-	}
-
-	scope := util.NewStringSet(strings.Split(param.Scope, " ")...)
-	request, err := client.CreateGrantRequest(param.ResponseType, param.RedirectURI, param.State, scope)
-	if err != nil {
-		PrintErrorHTML(w, r, err, http.StatusBadRequest)
-		return
-	}
-
-	w.Header().Add("Cache-Control", "no-store")
-	http.Redirect(w, r, "/oauth/login_page?request_id="+request.Token, http.StatusFound)
+	createGrantRequest(w, r, "/oauth/login_page")
 }
 
 type loginData struct {

--- a/web/registration.go
+++ b/web/registration.go
@@ -117,6 +117,14 @@ func (rh *registration) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	valAccount.RequestId = r.Form.Get("request_id")
+	_, ok := data.GetGrantRequest(valAccount.RequestId)
+	if !ok {
+		// TODO check if handling this fail is sufficient or if there should be
+		// a redirect to registration_init and start the registration process again.
+		PrintErrorHTML(w, r, "Grant request does not exist", http.StatusBadRequest)
+		return
+	}
 	valAccount.ValidationError = valAccount.Account.Validate()
 
 	if pw.Password != pw.PasswordControl {

--- a/web/registration.go
+++ b/web/registration.go
@@ -26,6 +26,17 @@ type validateAccount struct {
 	CaptchaResolve string
 }
 
+// RegistrationInit creates a grant request for an account registration
+// and redirects to the actual registration entry form.
+func RegistrationInit(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if query.Get("response_type") != "client" {
+		PrintErrorHTML(w, r, "Invalid response type", http.StatusBadRequest)
+		return
+	}
+	createGrantRequest(w, r, "/oauth/registration_page")
+}
+
 // RegistrationPage displays entry fields required for the creation of a new gin account
 func RegistrationPage(w http.ResponseWriter, r *http.Request) {
 	valAccount := &validateAccount{}

--- a/web/registration_test.go
+++ b/web/registration_test.go
@@ -150,7 +150,18 @@ func TestRegistrationHandler(t *testing.T) {
 		t.Errorf("Expected empty location header, but was '%s'", redirect.String())
 	}
 
+	// test that a request without valid request id returns a BadRequest
+	request, _ = http.NewRequest("POST", registrationURL, strings.NewReader(body.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Expected code %d but got %d\n", http.StatusBadRequest, response.Code)
+	}
+
 	// test that a request with correct form content but missing captcha stays on the same page
+	body.Add("request_id", "QPJ64HK0")
 	request, _ = http.NewRequest("POST", registrationURL, strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
@@ -191,6 +202,9 @@ func TestRegistrationHandler(t *testing.T) {
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
+	if response.Code != http.StatusFound {
+		t.Errorf("Expected status %d but got status %d\n", http.StatusFound, response.Code)
+	}
 	redirect, err = url.Parse(response.Header().Get("Location"))
 	if err != nil {
 		t.Error(err)

--- a/web/registration_test.go
+++ b/web/registration_test.go
@@ -58,11 +58,52 @@ func TestRegistrationInit(t *testing.T) {
 }
 
 func TestRegistrationPage(t *testing.T) {
+	const uri = "/oauth/registration_page"
+	const invalidID = "invalidID"
+	const invalidCodeID = "B4LIMIMB"
+	const validID = "QPJ64HK0"
+
 	handler := InitTestHttpHandler(t)
 
-	request, _ := http.NewRequest("GET", "/oauth/registration_page", strings.NewReader(""))
+	// Test fail with missing requestID
+	request, _ := http.NewRequest("GET", uri, strings.NewReader(""))
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
+	}
+
+	// Test fail with invalid grant request ID
+	queryVals := &url.Values{}
+	queryVals.Add("request_id", invalidID)
+
+	request, _ = http.NewRequest("GET", uri+"?"+queryVals.Encode(), strings.NewReader(""))
+	request.URL.Query().Add("request_id", invalidID)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
+	}
+
+	// Test fail with invalid grant request scope
+	queryVals.Set("request_id", invalidCodeID)
+	request, _ = http.NewRequest("GET", uri+"?"+queryVals.Encode(), strings.NewReader(""))
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusBadRequest, response.Code)
+	}
+
+	// Test success with valid grant request
+	queryVals.Set("request_id", validID)
+	request, _ = http.NewRequest("GET", uri+"?"+queryVals.Encode(), strings.NewReader(""))
+	request.URL.Query().Add("request_id", validID)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
 	if response.Code != http.StatusOK {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusOK, response.Code)
 	}

--- a/web/routes.go
+++ b/web/routes.go
@@ -35,6 +35,7 @@ func RegisterRoutes(r *mux.Router) {
 		Methods("POST")
 	oauth.HandleFunc("/logout/{token}", Logout).
 		Methods("GET")
+	oauth.HandleFunc("/registration_init", RegistrationInit).Methods("GET")
 	oauth.HandleFunc("/registration_page", RegistrationPage).Methods("GET")
 	oauth.Handle("/registration", RegistrationHandler(captcha.VerifyString)).Methods("POST")
 	oauth.HandleFunc("/registered_page", RegisteredPage).Methods("GET")


### PR DESCRIPTION
- closes issue #107
- adds a web/commons function for creating grant requests and forwarding to a URI.
- adds a check for existing client state to Client.CreateGrantRequests.
- adds an additional grant request entry to the test database to test for account-create.
- fixes deploy script bugs