### PR TITLE
Automatic redirect to gin-ui after registration

### DIFF
--- a/resources/conf/clients.yml
+++ b/resources/conf/clients.yml
@@ -18,6 +18,7 @@
     - account-admin
   RedirectURIs:
     - http://localhost:8080/oauth/login
+    - http://localhost:8080
 - UUID: 5b2ca112-0ecc-41ff-8315-221024345ab8
   Name: gin-shell
   Secret: secret

--- a/resources/conf/clients.yml
+++ b/resources/conf/clients.yml
@@ -18,7 +18,6 @@
     - account-admin
   RedirectURIs:
     - http://localhost:8080/oauth/login
-    - http://localhost:8080/notice
 - UUID: 5b2ca112-0ecc-41ff-8315-221024345ab8
   Name: gin-shell
   Secret: secret

--- a/resources/templates/success.html
+++ b/resources/templates/success.html
@@ -3,6 +3,9 @@
 <h1>
     {{ .Header }}
 </h1>
+
+<br/>
+
 <p>
     {{ .Message }}
 </p>

--- a/web/commons.go
+++ b/web/commons.go
@@ -52,3 +52,15 @@ func createGrantRequest(w http.ResponseWriter, r *http.Request, forwardURI strin
 	w.Header().Add("Cache-Control", "no-store")
 	http.Redirect(w, r, forwardURI+"?"+queryVals.Encode(), http.StatusFound)
 }
+
+// redirectionScript returns a java script block that upon window loading
+// redirects after a given delay to a given redirectURI.
+func redirectionScript(redirectURI string, delay int) string {
+	scriptBlock := "<script type=\"text/javascript\">"
+	scriptBlock += fmt.Sprintf("var url = \"%s\";", redirectURI)
+	scriptBlock += fmt.Sprintf("window.onload = function (){setTimeout(redirect, %d);};", delay)
+	scriptBlock += "function redirect(){window.location.replace(url);};"
+	scriptBlock += "</script>"
+
+	return scriptBlock
+}

--- a/web/commons_test.go
+++ b/web/commons_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -128,5 +129,19 @@ func TestCreateGrantRequest(t *testing.T) {
 	}
 	if !strings.Contains(location.RawQuery, "request_id=") {
 		t.Errorf("Request token is missing from redirect uri query: %q\n", location.RawQuery)
+	}
+}
+
+func TestRedirectionScript(t *testing.T) {
+	const uri = "https://example.com"
+	const delay = 500
+
+	script := redirectionScript(uri, delay)
+
+	if !strings.Contains(script, uri) {
+		t.Errorf("Script block does not contain uri %q: \n%q\n", uri, script)
+	}
+	if !strings.Contains(script, strconv.Itoa(delay)) {
+		t.Errorf("Script block does not contain delay %q: \n%q\n", delay, script)
 	}
 }

--- a/web/registration.go
+++ b/web/registration.go
@@ -11,6 +11,7 @@ package web
 import (
 	"database/sql"
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/url"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/G-Node/gin-auth/data"
 	"github.com/G-Node/gin-auth/util"
 	"github.com/dchest/captcha"
-	"html/template"
 )
 
 type validateAccount struct {
@@ -227,9 +227,17 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 	message := "You are only one step away from using your gin account! <br/><br/>"
 	message += "An e-mail with an activation code has been sent to your e-mail address, "
 	message += "please use the link within the e-mail to activate your account. <br/><br/>"
-	message += fmt.Sprintf("You can also return to the <a href=\"%s\">gin main page</a>",
+	message += "You will be automatically redirected to the gin main page, "
+	message += fmt.Sprintf("you can also use <a href=\"%s\">this link</a> to return",
 		conf.GetExternals().GinUiURL)
-	message += " and continue browsing all available public repositories."
+	message += " and continue browsing the available public repositories."
+
+	// Force redirect to gin ui using java script
+	message += "<script type=\"text/javascript\">"
+	message += fmt.Sprintf("var url = \"%s\";", conf.GetExternals().GinUiURL)
+	message += "window.onload = function (){setTimeout(redirect, 10000);};"
+	message += "function redirect(){window.location.replace(url);};"
+	message += "</script>"
 
 	safeMessage := template.HTML(message)
 

--- a/web/registration.go
+++ b/web/registration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/G-Node/gin-auth/data"
 	"github.com/G-Node/gin-auth/util"
 	"github.com/dchest/captcha"
+	"html/template"
 )
 
 type validateAccount struct {
@@ -222,14 +223,20 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	head := "Account registered"
-	message := "Your account activation is pending. "
-	message += "An e-mail with an activation code has been sent to your e-mail address."
+	head := "Your gin account has been successfully registered!"
+	message := "You are only one step away from using your gin account! <br/><br/>"
+	message += "An e-mail with an activation code has been sent to your e-mail address, "
+	message += "please use the link within the e-mail to activate your account. <br/><br/>"
+	message += fmt.Sprintf("You can also return to the <a href=\"%s\">gin main page</a>",
+		conf.GetExternals().GinUiURL)
+	message += " and continue browsing all available public repositories."
+
+	safeMessage := template.HTML(message)
 
 	info := struct {
 		Header  string
-		Message string
-	}{head, message}
+		Message template.HTML
+	}{head, safeMessage}
 
 	w.Header().Add("Content-Type", "text/html")
 	tmpl := conf.MakeTemplate("success.html")

--- a/web/registration.go
+++ b/web/registration.go
@@ -210,14 +210,16 @@ func (rh *registration) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/oauth/registered_page?"+urlValue.Encode(), http.StatusFound)
 }
 
-// RegisteredPage displays information about how a newly created gin account can be activated.
+// RegisteredPage displays gin account activation information and
+// redirects back to the grant request redirection URI after a brief delay
+// using java script.
 func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query() == nil {
 		PrintErrorHTML(w, r, "Grant request id is missing", http.StatusBadRequest)
 		return
 	}
 
-	_, exists := data.GetGrantRequest(r.URL.Query().Get("request_id"))
+	request, exists := data.GetGrantRequest(r.URL.Query().Get("request_id"))
 	if !exists {
 		PrintErrorHTML(w, r, "Grant request does not exist", http.StatusBadRequest)
 		return
@@ -234,8 +236,8 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 
 	// Force redirect to gin ui using java script
 	message += "<script type=\"text/javascript\">"
-	message += fmt.Sprintf("var url = \"%s\";", conf.GetExternals().GinUiURL)
-	message += "window.onload = function (){setTimeout(redirect, 10000);};"
+	message += fmt.Sprintf("var url = \"%s\";", request.RedirectURI)
+	message += "window.onload = function (){setTimeout(redirect, 8000);};"
 	message += "function redirect(){window.location.replace(url);};"
 	message += "</script>"
 

--- a/web/registration.go
+++ b/web/registration.go
@@ -214,6 +214,8 @@ func (rh *registration) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // redirects back to the grant request redirection URI after a brief delay
 // using java script.
 func RegisteredPage(w http.ResponseWriter, r *http.Request) {
+	const redirectionDelay = 8000
+
 	if r.URL.Query() == nil {
 		PrintErrorHTML(w, r, "Grant request id is missing", http.StatusBadRequest)
 		return
@@ -234,12 +236,8 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 		conf.GetExternals().GinUiURL)
 	message += " and continue browsing the available public repositories."
 
-	// Force redirect to gin ui using java script
-	message += "<script type=\"text/javascript\">"
-	message += fmt.Sprintf("var url = \"%s\";", request.RedirectURI)
-	message += "window.onload = function (){setTimeout(redirect, 8000);};"
-	message += "function redirect(){window.location.replace(url);};"
-	message += "</script>"
+	// Add java script block to force redirect to the grant request redirection URI.
+	message += redirectionScript(request.RedirectURI, redirectionDelay)
 
 	safeMessage := template.HTML(message)
 

--- a/web/registration.go
+++ b/web/registration.go
@@ -10,7 +10,6 @@ package web
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -217,7 +216,7 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	request, exists := data.GetGrantRequest(r.URL.Query().Get("request_id"))
+	_, exists := data.GetGrantRequest(r.URL.Query().Get("request_id"))
 	if !exists {
 		PrintErrorHTML(w, r, "Grant request does not exist", http.StatusBadRequest)
 		return
@@ -231,20 +230,6 @@ func RegisteredPage(w http.ResponseWriter, r *http.Request) {
 		Header  string
 		Message string
 	}{head, message}
-
-	if request.RedirectURI != "" {
-		w.Header().Add("Cache-Control", "no-store")
-		w.Header().Add("Content-Type", "application/json")
-
-		enc := json.NewEncoder(w)
-		enc.Encode(info)
-
-		urlValue := &url.Values{}
-		urlValue.Add("state", request.State)
-
-		http.Redirect(w, r, request.RedirectURI+"?"+urlValue.Encode(), http.StatusFound)
-		return
-	}
 
 	w.Header().Add("Content-Type", "text/html")
 	tmpl := conf.MakeTemplate("success.html")

--- a/web/registration_test.go
+++ b/web/registration_test.go
@@ -257,21 +257,6 @@ func TestRegisteredPage(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusOK, response.Code)
 	}
-
-	grantRequest, exists := data.GetGrantRequest(validToken)
-	if !exists {
-		t.Error("Grant request does not exist")
-	}
-	redirect, err := url.Parse(response.Header().Get("Location"))
-	if err != nil {
-		t.Error(err)
-	}
-	if !strings.Contains(redirect.String(), grantRequest.RedirectURI) {
-		t.Errorf("Expected to be redirected to '%s', but was '%s'", grantRequest.RedirectURI, redirect.String())
-	}
-	if !strings.Contains(redirect.Query().Get("state"), grantRequest.State) {
-		t.Errorf("Missing or invalid state in reponse query: '%s'", redirect.RawQuery)
-	}
 }
 
 func TestActivation(t *testing.T) {


### PR DESCRIPTION
See G-Node/gin-ui#40 for more details.

IMPORTANT for deployment of this PR to the server:
- `clients.yml` on the server has to be updated with production server specific URI of _gin-ui_ before deploying these changes.

A successful registration now
- displays a status message.
- shows information how to proceed with account activation.
- provides a link to _gin-ui_.
- automatically redirects back to the grant request redirection URI after a delay using javascript.
