### PR TITLE
Login with username/email and various other changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
  - 1.7
+ - 1.8
  - tip
 
 services:

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@
 # GIN-Auth
 
 **G**-Node **In**frastructure Authentication Provider
+
+gin-auth is an OAuth2 authentication server for the **GIN** (**G**-Node **IN**frastructure) services.
+
+Associated projects are
+- [gin-repo](https://github.com/G-Node/gin-repo): The GIN repository server.
+- [gin-ui](https://github.com/G-Node/gin-ui): The GIN web interface based on VueJs.
+- [gin-cli](https://github.com/G-Node/gin-cli): The GIN command line client.
+
+A detailed description of the GIN project can be found at the [G-Node projects site](g-node.github.io).

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -369,6 +369,7 @@ func GetLogLocation() *LogLocations {
 
 // Externals contains links to external resources e.g. required for links in templates.
 type Externals struct {
+	ThemeURL string
 	GinUiURL string
 }
 
@@ -388,6 +389,7 @@ func GetExternals() *Externals {
 
 		e := &struct {
 			Externals struct {
+				ThemeURL string `yaml:"ThemeURL"`
 				GinUiURL string `yaml:"GinUiURL"`
 			}
 		}{}
@@ -397,6 +399,7 @@ func GetExternals() *Externals {
 		}
 
 		externals = &Externals{
+			ThemeURL: e.Externals.ThemeURL,
 			GinUiURL: e.Externals.GinUiURL,
 		}
 	}

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -78,7 +78,13 @@ func TestSmtpCheck(t *testing.T) {
 
 func TestGetExternals(t *testing.T) {
 	externals := GetExternals()
-	if externals == nil || externals.GinUiURL == "" {
+	if externals == nil {
 		t.Error("Error initializing server externals")
+	}
+	if externals.GinUiURL == "" {
+		t.Error("Missing Gin UI URL")
+	}
+	if externals.ThemeURL == "" {
+		t.Error("Missing Theme URL")
 	}
 }

--- a/conf/util.go
+++ b/conf/util.go
@@ -38,12 +38,20 @@ func MakeTemplate(name string) *template.Template {
 		panic(err)
 	}
 
-	// parse gin web ui URL from config into the layout template
-	s := fmt.Sprintf("{{ define \"ginui\" }}%s{{ end }}", GetExternals().GinUiURL)
+	// parse theme URL from config into the layout template
+	s := fmt.Sprintf("{{ define \"theme\" }}%s{{ end }}", GetExternals().ThemeURL)
+	fmt.Printf("[DEBUG] %s\n", s)
+
 	tmpl, err = tmpl.Parse(s)
 	if err != nil {
 		panic(err)
 	}
 
+	// parse gin web ui URL from config into the layout template
+	s = fmt.Sprintf("{{ define \"ginui\" }}%s{{ end }}", GetExternals().GinUiURL)
+	tmpl, err = tmpl.Parse(s)
+	if err != nil {
+		panic(err)
+	}
 	return tmpl
 }

--- a/data/account.go
+++ b/data/account.go
@@ -104,6 +104,21 @@ func GetAccountByLogin(login string) (*Account, bool) {
 	return account, err == nil
 }
 
+// GetAccountByCredential returns an active account (non disabled, no activation code,
+// no reset password code) with matching login or email address.
+// Returns false if no account with such login or email address exists.
+func GetAccountByCredential(id string) (*Account, bool) {
+	const q = `SELECT * FROM ActiveAccounts WHERE login=$1 or email=$1`
+
+	account := &Account{}
+	err := database.Get(account, q, id)
+	if err != nil && err != sql.ErrNoRows {
+		panic(err)
+	}
+
+	return account, err == nil
+}
+
 // GetAccountByActivationCode returns an account with matching activation code.
 // Returns false if no account with the activation code can be found.
 func GetAccountByActivationCode(code string) (*Account, bool) {

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -88,6 +88,45 @@ func TestGetAccountByLogin(t *testing.T) {
 	}
 }
 
+func TestGetAccountByCredential(t *testing.T) {
+	defer util.FailOnPanic(t)
+	InitTestDb(t)
+
+	const validLogin = "bob"
+	const validEmail = "aclic@foo.com"
+
+	acc, ok := GetAccountByCredential(validLogin)
+	if !ok {
+		t.Errorf("Account for login '%s' was not found.\n", validLogin)
+	}
+	if acc.Login != validLogin {
+		t.Errorf("Retrieved account for '%s' but got %v.\n", validLogin, acc)
+	}
+
+	acc, ok = GetAccountByCredential(validEmail)
+	if !ok {
+		t.Errorf("Account for email '%s' was not found.\n", validEmail)
+	}
+	if acc.Email != validEmail {
+		t.Errorf("Retrieved account for '%s' but got '%v'.\n", validEmail, acc)
+	}
+
+	_, ok = GetAccountByCredential("doesNotExist")
+	if ok {
+		t.Error("Account should not exist.")
+	}
+
+	// Test whole barrage of inactive accounts
+	inactiveLogin := []string{"inact_log1", "inact_log2", "inact_log3", "inact_log4",
+		"inact_log5", "inact_log6"}
+	for _, v := range inactiveLogin {
+		_, ok = GetAccountByCredential(v)
+		if ok {
+			t.Errorf("Account with login '%s' should not exist", v)
+		}
+	}
+}
+
 func TestGetAccountByActivationCode(t *testing.T) {
 	defer util.FailOnPanic(t)
 	InitTestDb(t)

--- a/resources/conf/server.yml
+++ b/resources/conf/server.yml
@@ -16,4 +16,5 @@ log:
   Access: gin-auth.access.log
   Error: gin-auth.error.log
 externals:
+  ThemeURL: "//projects.g-node.org/assets/gnode-bootstrap-theme/1.1.0-snapshot"
   GinUiURL: "http://localhost:8080"

--- a/resources/templates/layout.html
+++ b/resources/templates/layout.html
@@ -37,7 +37,7 @@
                 <div class="col-sm-6 display-cell">
                     <ul class="list-inline">
                         <li>© G-Node</li>
-                        <li><a href="http://www.g-node.org/gin_terms">Terms of usage</a></li>
+                        <li><a href="http://www.g-node.org/gin_terms">Terms of Use</a></li>
                     </ul>
                 </div>
                 <div class="col-sm-6 display-cell">

--- a/resources/templates/layout.html
+++ b/resources/templates/layout.html
@@ -42,9 +42,9 @@
                 </div>
                 <div class="col-sm-6 display-cell">
                     <ul class="list-inline pull-right">
-                        <li><a href="https://gin.g-node.org/info/about">About</a></li>
-                        <li><a href="https://gin.g-node.org/info/imprint">Imprint</a></li>
-                        <li><a href="https://gin.g-node.org/info/contact">Contact</a></li>
+                        <li><a href="{{ template "ginui" . }}/info/about">About</a></li>
+                        <li><a href="{{ template "ginui" . }}/info/imprint">Imprint</a></li>
+                        <li><a href="{{ template "ginui" . }}/info/contact">Contact</a></li>
                     </ul>
                 </div>
             </div>

--- a/resources/templates/layout.html
+++ b/resources/templates/layout.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet"
-          href="//projects.g-node.org/assets/gnode-bootstrap-theme/1.1.0-snapshot/css/bootstrap.min.css">
+          href="{{ template "theme" . }}/css/bootstrap.min.css">
     <link rel="shortcut icon" type="image/png"
-          href="//projects.g-node.org/assets/gnode-bootstrap-theme/1.1.0-snapshot/img/favicon.png">
+          href="{{ template "theme" . }}/img/favicon.png">
 
     <title>G-Node GIN</title>
 </head>
@@ -52,7 +52,7 @@
     </nav>
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="//projects.g-node.org/assets/gnode-bootstrap-theme/1.1.0-snapshot/js/bootstrap.min.js"></script>
+    <script src="{{ template "theme" . }}/js/bootstrap.min.js"></script>
 </body>
 </html>
 {{ end }}

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -144,7 +144,7 @@
 
     <hr>
     <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9">Please verify you are a person:</div>
+        <div class="col-sm-offset-3 col-sm-9">Please verify that you are a person:</div>
         <div class="col-sm-offset-3 col-sm-3">
             <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
         </div>

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -16,7 +16,8 @@
     <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
         <label for="reg-title" class="col-sm-3 control-label">Title</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-title" name="title" placeholder="Title" value="{{ .Title.String }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-title" name="title"
+                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
             {{ if .FieldErrors.title }}
                 <span class="help-block">{{ .FieldErrors.title }}</span>
             {{ end }}
@@ -25,7 +26,8 @@
     <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
         <label for="reg-fn" class="col-sm-3 control-label">First name *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-fn" name="first_name" placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-fn" name="first_name"
+                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
             {{ if .FieldErrors.first_name }}
                 <span class="help-block">{{ .FieldErrors.first_name }}</span>
             {{ end }}
@@ -34,7 +36,8 @@
     <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
         <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-mn" name="middle_name" placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-mn" name="middle_name"
+                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
             {{ if .FieldErrors.middle_name }}
                 <span class="help-block">{{ .FieldErrors.middle_name }}</span>
             {{ end }}
@@ -43,7 +46,8 @@
     <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
         <label for="reg-ln" class="col-sm-3 control-label">Last name *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-ln" name="last_name" placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-ln" name="last_name"
+                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
             {{ if .FieldErrors.last_name }}
                 <span class="help-block">{{ .FieldErrors.last_name }}</span>
             {{ end }}
@@ -52,7 +56,8 @@
     <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
         <label for="reg-login" class="col-sm-3 control-label">Login *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-login" name="login" placeholder="Login" value="{{ .Login }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-login" name="login"
+                   placeholder="Login" value="{{ .Login }}" maxlength="512">
             {{ if .FieldErrors.login }}
                 <span class="help-block">{{ .FieldErrors.login }}</span>
             {{ end }}
@@ -61,14 +66,16 @@
     <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
         <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-email" name="email" placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-email" name="email"
+                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
             <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
         </div>
     </div>
     <div class="form-group">
         <div class="col-sm-offset-3 col-sm-9 checkbox">
             <label for="reg-email-public">
-                <input type="checkbox" id="reg-email-public" name="is_email_public" value="true" {{ if .IsEmailPublic }} checked {{ end }}>
+                <input type="checkbox" id="reg-email-public" name="is_email_public"
+                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
                 Make e-mail public
                 <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
                   title="If you make your e-mail address public, it will be visible for other logged in users.">
@@ -83,7 +90,8 @@
     <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
         <label for="reg-institute" class="col-sm-3 control-label">Institution *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-institute" name="institute" placeholder="Institute" value="{{ .Institute }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-institute" name="institute"
+                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
             {{ if .FieldErrors.institute }}
                 <span class="help-block">{{ .FieldErrors.institute }}</span>
             {{ end }}
@@ -93,7 +101,8 @@
     <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
         <label for="reg-department" class="col-sm-3 control-label">Department *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-department" name="department" placeholder="Department" value="{{ .Department }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-department" name="department"
+                   placeholder="Department" value="{{ .Department }}" maxlength="512">
             {{ if .FieldErrors.department }}
                 <span class="help-block">{{ .FieldErrors.department }}</span>
             {{ end }}
@@ -102,7 +111,8 @@
     <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
         <label for="reg-city" class="col-sm-3 control-label">City *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-city" name="city" placeholder="City" value="{{ .City }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-city" name="city"
+                   placeholder="City" value="{{ .City }}" maxlength="512">
             {{ if .FieldErrors.city }}
                 <span class="help-block">{{ .FieldErrors.city }}</span>
             {{ end }}
@@ -111,7 +121,8 @@
     <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
         <label for="reg-country" class="col-sm-3 control-label">Country *</label>
         <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-country" name="country" placeholder="Country" value="{{ .Country }}" maxlength="512">
+            <input type="text" class="form-control" id="reg-country" name="country"
+                   placeholder="Country" value="{{ .Country }}" maxlength="512">
             {{ if .FieldErrors.country }}
                 <span class="help-block">{{ .FieldErrors.country }}</span>
             {{ end }}
@@ -120,7 +131,8 @@
     <div class="form-group">
         <div class="col-sm-offset-3 col-sm-9 checkbox">
             <label for="reg-affiliation-public">
-                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"  value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
+                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
+                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
                 Make affiliation public
                 <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
                       title="If you make your affiliation public, it will be visible for other logged in users.">
@@ -135,13 +147,15 @@
     <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
         <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
         <div class="col-sm-9">
-            <input type="password" class="form-control" id="reg-password-input" name="password" placeholder="Password" maxlength="512">
+            <input type="password" class="form-control" id="reg-password-input"
+                   name="password" placeholder="Password" maxlength="512">
         </div>
     </div>
     <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
         <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
         <div class="col-sm-9">
-            <input type="password" class="form-control" id="reg-password-control" name="password_control" placeholder="Password" maxlength="512">
+            <input type="password" class="form-control" id="reg-password-control"
+                   name="password_control" placeholder="Password" maxlength="512">
             {{ if .FieldErrors.password }}
                 <span class="help-block">{{ .FieldErrors.password }}</span>
             {{ end }}
@@ -162,7 +176,8 @@
         <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
         <div class="col-sm-9">
             <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
-            <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve" placeholder="Enter characters">
+            <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
+                   placeholder="Enter characters">
             {{ if .FieldErrors.captcha }}
                 <span class="help-block">{{ .FieldErrors.captcha }}</span>
             {{ end }}

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -167,7 +167,7 @@
     <div class="form-group">
         <div class="col-sm-9 col-sm-offset-3">
             <p>By clicking "Create account", you agree to our
-                <a href="http://www.g-node.org/gin_terms">Terms of usage</a>.
+                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
             </p>
         </div>
     </div>

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -70,7 +70,7 @@
             <label for="reg-email-public">
                 <input type="checkbox" id="reg-email-public" name="is_email_public" value="true" {{ if .IsEmailPublic }} checked {{ end }}>
                 Make e-mail public
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
                   title="If you make your e-mail address public, it will be visible for other logged in users.">
                 </span>
             </label>
@@ -122,7 +122,7 @@
             <label for="reg-affiliation-public">
                 <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"  value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
                 Make affiliation public
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
                       title="If you make your affiliation public, it will be visible for other logged in users.">
                 </span>
             </label>
@@ -200,5 +200,11 @@
         $('[data-toggle="tooltip"]').tooltip();
     })
 </script>
+
+<style type="text/css">
+    .glyph-blue {
+        color: rgb(85, 123, 185);
+    }
+</style>
 
 {{ end }}

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -78,7 +78,7 @@
                        value="true" {{ if .IsEmailPublic }} checked {{ end }}>
                 Make e-mail public
                 <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                  title="If you make your e-mail address public, it will be visible for other logged in users.">
+                  title="If you make your e-mail address public, it will be visible to other logged in users.">
                 </span>
             </label>
         </div>
@@ -135,7 +135,7 @@
                        value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
                 Make affiliation public
                 <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                      title="If you make your affiliation public, it will be visible for other logged in users.">
+                      title="If you make your affiliation public, it will be visible to other logged in users.">
                 </span>
             </label>
         </div>

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -70,6 +70,9 @@
             <label for="reg-email-public">
                 <input type="checkbox" id="reg-email-public" name="is_email_public" value="true" {{ if .IsEmailPublic }} checked {{ end }}>
                 Make e-mail public
+                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                  title="If you make your e-mail address public, it will be visible for other logged in users.">
+                </span>
             </label>
         </div>
     </div>
@@ -119,6 +122,9 @@
             <label for="reg-affiliation-public">
                 <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"  value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
                 Make affiliation public
+                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                      title="If you make your affiliation public, it will be visible for other logged in users.">
+                </span>
             </label>
         </div>
     </div>
@@ -180,7 +186,7 @@
     <br /><br />
 </form>
 
-<script>
+<script type="text/javascript">
     var xmlHttp = null;
     function reloadCaptcha() {
         var id = document.getElementById('reg-captcha-id').value;
@@ -189,6 +195,10 @@
         xmlHttp.send();
         document.getElementById('reg-image').src = "/captcha/"+ id +".png?"+ new Date().getTime();
     }
+
+    $(document).ready(function() {
+        $('[data-toggle="tooltip"]').tooltip();
+    })
 </script>
 
 {{ end }}

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -182,7 +182,7 @@ func LoginWithCredentials(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// verify login data
-	account, ok := data.GetAccountByLogin(param.Login)
+	account, ok := data.GetAccountByCredential(param.Login)
 	if !ok {
 		w.Header().Add("Cache-Control", "no-store")
 		http.Redirect(w, r, "/oauth/login_page?request_id="+request.Token, http.StatusFound)

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -350,6 +350,23 @@ func TestLoginWithCredentials(t *testing.T) {
 	if redirect.Query().Get("request_id") == "" {
 		t.Error("Request id not found")
 	}
+
+	// all OK for email
+	body = mkBody(validEmailToken, validEmail, pw)
+	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusFound {
+		t.Errorf("Response code '%d' expected but was '%d'", http.StatusFound, response.Code)
+	}
+	redirect, err = url.Parse(response.Header().Get("Location"))
+	if err != nil {
+		t.Error(err)
+	}
+	if redirect.Path != "/login" {
+		t.Errorf("Wrong redirect, received path '%s'\n", redirect.Path)
+	}
 }
 
 func TestLogout(t *testing.T) {

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -275,13 +275,20 @@ func TestLoginWithSession(t *testing.T) {
 }
 
 func TestLoginWithCredentials(t *testing.T) {
+	const validLogin = "bob"
+	const validLoginToken = "B4LIMIMB"
+	const validEmail = "aclic@foo.com"
+	const validEmailToken = "U7JIKKYI"
+	const invalid = "doesnotexist"
+	const pw = "testtest"
+
 	handler := InitTestHttpHandler(t)
 
-	mkBody := func() *url.Values {
+	mkBody := func(t, l, p string) *url.Values {
 		body := &url.Values{}
-		body.Add("request_id", "U7JIKKYI")
-		body.Add("login", "bob")
-		body.Add("password", "testtest")
+		body.Add("request_id", t)
+		body.Add("login", l)
+		body.Add("password", p)
 		return body
 	}
 
@@ -295,8 +302,7 @@ func TestLoginWithCredentials(t *testing.T) {
 	}
 
 	// wrong request id
-	body := mkBody()
-	body.Set("request_id", "doesnotexist")
+	body := mkBody(invalid, validLogin, pw)
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
@@ -306,8 +312,7 @@ func TestLoginWithCredentials(t *testing.T) {
 	}
 
 	// wrong login
-	body = mkBody()
-	body.Set("login", "doesnotexist")
+	body = mkBody(validLoginToken, invalid, pw)
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
@@ -317,8 +322,7 @@ func TestLoginWithCredentials(t *testing.T) {
 	}
 
 	// wrong password
-	body = mkBody()
-	body.Set("password", "notapassword")
+	body = mkBody(validLoginToken, validLogin, invalid)
 	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
@@ -327,8 +331,9 @@ func TestLoginWithCredentials(t *testing.T) {
 		t.Errorf("Response code '%d' expected but was '%d'", http.StatusFound, response.Code)
 	}
 
-	// all OK
-	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(mkBody().Encode()))
+	// all OK for login
+	body = mkBody(validLoginToken, validLogin, pw)
+	request, _ = http.NewRequest("POST", "/oauth/login", strings.NewReader(body.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)


### PR DESCRIPTION
This pull request
- enables login with username and email.
- adds explanatory tooltip notes to "make public" email and affiliation checkboxes at the registration page.
- changes the `server.yml` config file to enable dynamic gin ui and bootstrap theme URL.
- adds minimal service description to `README.md`.
- adds go 1.8 build via travis.

Closes #128 and #129.

IMPORTANT for deployment of this PR to the server:
- `server.yml` on the server has to be updated with server specific entries before deploying these changes to the server.