### PR TITLE
New account registration

### DIFF
--- a/data/account.go
+++ b/data/account.go
@@ -337,24 +337,6 @@ func (acc *Account) Validate() *util.ValidationError {
 	if !(len(acc.Email) > 2) || !strings.Contains(acc.Email, "@") {
 		valErr.FieldErrors["email"] = "Please add a valid e-mail address"
 	}
-	if acc.FirstName == "" {
-		valErr.FieldErrors["first_name"] = "Please add first name"
-	}
-	if acc.LastName == "" {
-		valErr.FieldErrors["last_name"] = "Please add last name"
-	}
-	if acc.Institute == "" {
-		valErr.FieldErrors["institute"] = "Please add institution"
-	}
-	if acc.Department == "" {
-		valErr.FieldErrors["department"] = "Please add department"
-	}
-	if acc.City == "" {
-		valErr.FieldErrors["city"] = "Please add city"
-	}
-	if acc.Country == "" {
-		valErr.FieldErrors["country"] = "Please add country"
-	}
 
 	const fieldLength = 512
 	var lenMessage = fmt.Sprintf("Entry too long, please shorten to %d characters", fieldLength)

--- a/data/account_test.go
+++ b/data/account_test.go
@@ -622,56 +622,8 @@ func TestValidate(t *testing.T) {
 		t.Errorf("Expected missing email error, but got: '%s'", valErr.FieldErrors["email"])
 	}
 
-	// Test missing first name
-	account.Email = "noone@example.com"
-	account.FirstName = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["first_name"] != "Please add first name" {
-		t.Errorf("Expected missing first name error, but got: '%s'", valErr.FieldErrors["first_name"])
-	}
-
-	// Test missing last name
-	account.FirstName = "fn"
-	account.LastName = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["last_name"] != "Please add last name" {
-		t.Errorf("Expected missing last name error, but got: '%s'", valErr.FieldErrors["last_name"])
-	}
-
-	// Test missing institute
-	account.LastName = "ln"
-	account.Institute = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["institute"] != "Please add institution" {
-		t.Errorf("Expected missing institute error, but got: '%s'", valErr.FieldErrors["institute"])
-	}
-
-	// Test missing department
-	account.Institute = "Inst"
-	account.Department = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["department"] != "Please add department" {
-		t.Errorf("Expected missing department error, but got: '%s'", valErr.FieldErrors["department"])
-	}
-
-	// Test missing city
-	account.Department = "Dep"
-	account.City = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["city"] != "Please add city" {
-		t.Errorf("Expected missing city error, but got: '%s'", valErr.FieldErrors["city"])
-	}
-
-	// Test missing country
-	account.City = "cty"
-	account.Country = ""
-	valErr = account.Validate()
-	if valErr.FieldErrors["country"] != "Please add country" {
-		t.Errorf("Expected missing country error, but got: '%s'", valErr.FieldErrors["country"])
-	}
-
 	// Test valid
-	account.Country = "ctry"
+	account.Email = "noone@example.com"
 	valErr = account.Validate()
 	if valErr.Message != "" {
 		t.Errorf("Expected valid registration , but got error in fields: '%s'", valErr.FieldErrors)

--- a/resources/conf/server.yml
+++ b/resources/conf/server.yml
@@ -16,5 +16,5 @@ log:
   Access: gin-auth.access.log
   Error: gin-auth.error.log
 externals:
-  ThemeURL: "//projects.g-node.org/assets/gnode-bootstrap-theme/1.1.0-snapshot"
+  ThemeURL: "//projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot"
   GinUiURL: "http://localhost:8080"

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -247,10 +247,4 @@
     }
 </script>
 
-<style type="text/css">
-    .glyph-blue {
-        color: rgb(85, 123, 185);
-    }
-</style>
-
 {{ end }}

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -11,139 +11,17 @@
 
 <form action="/oauth/registration" method="post" class="form-horizontal">
 
-    <h4>User information</h4>
-    <hr>
-    <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
-        <label for="reg-title" class="col-sm-3 control-label">Title</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-title" name="title"
-                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
-            {{ if .FieldErrors.title }}
-                <span class="help-block">{{ .FieldErrors.title }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
-        <label for="reg-fn" class="col-sm-3 control-label">First name *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-fn" name="first_name"
-                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
-            {{ if .FieldErrors.first_name }}
-                <span class="help-block">{{ .FieldErrors.first_name }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
-        <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-mn" name="middle_name"
-                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
-            {{ if .FieldErrors.middle_name }}
-                <span class="help-block">{{ .FieldErrors.middle_name }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
-        <label for="reg-ln" class="col-sm-3 control-label">Last name *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-ln" name="last_name"
-                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
-            {{ if .FieldErrors.last_name }}
-                <span class="help-block">{{ .FieldErrors.last_name }}</span>
-            {{ end }}
-        </div>
-    </div>
+    <h4>Account information</h4>
     <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
         <label for="reg-login" class="col-sm-3 control-label">Login *</label>
         <div class="col-sm-9">
             <input type="text" class="form-control" id="reg-login" name="login"
                    placeholder="Login" value="{{ .Login }}" maxlength="512">
             {{ if .FieldErrors.login }}
-                <span class="help-block">{{ .FieldErrors.login }}</span>
+            <span class="help-block">{{ .FieldErrors.login }}</span>
             {{ end }}
         </div>
     </div>
-    <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
-        <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-email" name="email"
-                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
-            <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9 checkbox">
-            <label for="reg-email-public">
-                <input type="checkbox" id="reg-email-public" name="is_email_public"
-                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
-                Make e-mail public
-                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                  title="If you make your e-mail address public, it will be visible to other logged in users.">
-                </span>
-            </label>
-        </div>
-    </div>
-    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
-
-    <h4>Affiliation</h4>
-    <hr>
-    <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
-        <label for="reg-institute" class="col-sm-3 control-label">Institution *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-institute" name="institute"
-                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
-            {{ if .FieldErrors.institute }}
-                <span class="help-block">{{ .FieldErrors.institute }}</span>
-            {{ end }}
-        </div>
-    </div>
-
-    <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
-        <label for="reg-department" class="col-sm-3 control-label">Department *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-department" name="department"
-                   placeholder="Department" value="{{ .Department }}" maxlength="512">
-            {{ if .FieldErrors.department }}
-                <span class="help-block">{{ .FieldErrors.department }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
-        <label for="reg-city" class="col-sm-3 control-label">City *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-city" name="city"
-                   placeholder="City" value="{{ .City }}" maxlength="512">
-            {{ if .FieldErrors.city }}
-                <span class="help-block">{{ .FieldErrors.city }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
-        <label for="reg-country" class="col-sm-3 control-label">Country *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-country" name="country"
-                   placeholder="Country" value="{{ .Country }}" maxlength="512">
-            {{ if .FieldErrors.country }}
-                <span class="help-block">{{ .FieldErrors.country }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9 checkbox">
-            <label for="reg-affiliation-public">
-                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
-                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
-                Make affiliation public
-                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                      title="If you make your affiliation public, it will be visible to other logged in users.">
-                </span>
-            </label>
-        </div>
-    </div>
-
-
-    <h4>Password</h4>
-    <hr>
     <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
         <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
         <div class="col-sm-9">
@@ -157,8 +35,32 @@
             <input type="password" class="form-control" id="reg-password-control"
                    name="password_control" placeholder="Password" maxlength="512">
             {{ if .FieldErrors.password }}
-                <span class="help-block">{{ .FieldErrors.password }}</span>
+            <span class="help-block">{{ .FieldErrors.password }}</span>
             {{ end }}
+        </div>
+    </div>
+    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
+    <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
+        <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-email" name="email"
+                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
+            {{ if .FieldErrors.email }}
+            <span class="help-block">{{ .FieldErrors.email }}</span>
+            {{ end }}
+            <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-9 checkbox">
+            <label for="reg-email-public">
+                <input type="checkbox" id="reg-email-public" name="is_email_public"
+                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
+                Make e-mail public
+                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                      title="If you make your e-mail address public, it will be visible to other logged in users.">
+                </span>
+            </label>
         </div>
     </div>
 
@@ -179,8 +81,107 @@
             <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
                    placeholder="Enter characters">
             {{ if .FieldErrors.captcha }}
-                <span class="help-block">{{ .FieldErrors.captcha }}</span>
+            <span class="help-block">{{ .FieldErrors.captcha }}</span>
             {{ end }}
+        </div>
+    </div>
+
+    <h4>User information</h4>
+    <hr>
+    <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
+        <label for="reg-title" class="col-sm-3 control-label">Title</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-title" name="title"
+                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
+            {{ if .FieldErrors.title }}
+                <span class="help-block">{{ .FieldErrors.title }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
+        <label for="reg-fn" class="col-sm-3 control-label">First name</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-fn" name="first_name"
+                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
+            {{ if .FieldErrors.first_name }}
+                <span class="help-block">{{ .FieldErrors.first_name }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
+        <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-mn" name="middle_name"
+                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
+            {{ if .FieldErrors.middle_name }}
+                <span class="help-block">{{ .FieldErrors.middle_name }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
+        <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-ln" name="last_name"
+                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
+            {{ if .FieldErrors.last_name }}
+                <span class="help-block">{{ .FieldErrors.last_name }}</span>
+            {{ end }}
+        </div>
+    </div>
+
+    <h4>Affiliation</h4>
+    <hr>
+    <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
+        <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-institute" name="institute"
+                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
+            {{ if .FieldErrors.institute }}
+                <span class="help-block">{{ .FieldErrors.institute }}</span>
+            {{ end }}
+        </div>
+    </div>
+
+    <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
+        <label for="reg-department" class="col-sm-3 control-label">Department</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-department" name="department"
+                   placeholder="Department" value="{{ .Department }}" maxlength="512">
+            {{ if .FieldErrors.department }}
+                <span class="help-block">{{ .FieldErrors.department }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
+        <label for="reg-city" class="col-sm-3 control-label">City</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-city" name="city"
+                   placeholder="City" value="{{ .City }}" maxlength="512">
+            {{ if .FieldErrors.city }}
+                <span class="help-block">{{ .FieldErrors.city }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
+        <label for="reg-country" class="col-sm-3 control-label">Country</label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="reg-country" name="country"
+                   placeholder="Country" value="{{ .Country }}" maxlength="512">
+            {{ if .FieldErrors.country }}
+                <span class="help-block">{{ .FieldErrors.country }}</span>
+            {{ end }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-9 checkbox">
+            <label for="reg-affiliation-public">
+                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
+                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
+                Make affiliation public
+                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                      title="If you make your affiliation public, it will be visible to other logged in users.">
+                </span>
+            </label>
         </div>
     </div>
 

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -10,228 +10,222 @@
 {{ end }}
 
 <form action="/oauth/registration" method="post" class="form-horizontal">
-    <div class="step">
+    <div class="stepper">
         <div>
-            <div class="circle">1</div>
-            <div class="line"></div>
+            <div class="stp-circle">1</div>
+            <div class="stp-line"></div>
         </div>
         <div>
-            <div class="stepoffset title">Personal account</div>
-            <div class="stepoffset content">
-                <div id="step-1" class="collapse in">
-                    <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
-                        <label for="reg-login" class="col-sm-3 control-label">Login *</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-login" name="login"
-                                   placeholder="Login" value="{{ .Login }}" maxlength="512">
-                            {{ if .FieldErrors.login }}
-                            <span class="help-block">{{ .FieldErrors.login }}</span>
-                            {{ end }}
-                        </div>
+            <div class="stp-offset stp-title">Personal account</div>
+            <div class="stp-offset collapse in">
+                <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
+                    <label for="reg-login" class="col-sm-3 control-label">Login *</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-login" name="login"
+                               placeholder="Login" value="{{ .Login }}" maxlength="512">
+                        {{ if .FieldErrors.login }}
+                        <span class="help-block">{{ .FieldErrors.login }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-                        <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
-                        <div class="col-sm-9">
-                            <input type="password" class="form-control" id="reg-password-input"
-                                   name="password" placeholder="Password" maxlength="512">
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                    <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
+                    <div class="col-sm-9">
+                        <input type="password" class="form-control" id="reg-password-input"
+                               name="password" placeholder="Password" maxlength="512">
                     </div>
-                    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-                        <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
-                        <div class="col-sm-9">
-                            <input type="password" class="form-control" id="reg-password-control"
-                                   name="password_control" placeholder="Password" maxlength="512">
-                            {{ if .FieldErrors.password }}
-                            <span class="help-block">{{ .FieldErrors.password }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                    <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
+                    <div class="col-sm-9">
+                        <input type="password" class="form-control" id="reg-password-control"
+                               name="password_control" placeholder="Password" maxlength="512">
+                        {{ if .FieldErrors.password }}
+                        <span class="help-block">{{ .FieldErrors.password }}</span>
+                        {{ end }}
                     </div>
-                    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
-                    <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
-                        <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-email" name="email"
-                                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
-                            {{ if .FieldErrors.email }}
-                            <span class="help-block">{{ .FieldErrors.email }}</span>
-                            {{ end }}
-                            <span class="help-block">Note: A valid e-mail address is required to activate your account.</span>
-                        </div>
+                </div>
+                <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
+                <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
+                    <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-email" name="email"
+                               placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
+                        {{ if .FieldErrors.email }}
+                        <span class="help-block">{{ .FieldErrors.email }}</span>
+                        {{ end }}
+                        <span class="help-block">Note: A valid e-mail address is required to activate your account.</span>
                     </div>
-                    <div class="form-group">
-                        <div class="col-sm-offset-3 col-sm-9 checkbox">
-                            <label for="reg-email-public">
-                                <input type="checkbox" id="reg-email-public" name="is_email_public"
-                                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
-                                Make e-mail public
-                                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                                      title="If you make your e-mail address public, it will be visible to other logged in users.">
-                                </span>
-                            </label>
-                        </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-9 checkbox">
+                        <label for="reg-email-public">
+                            <input type="checkbox" id="reg-email-public" name="is_email_public"
+                                   value="true" {{ if .IsEmailPublic }} checked {{ end }}>
+                            Make e-mail public
+                            <span class="glyphicon glyphicon-info-sign c-blue-gnode" data-toggle="tooltip"
+                                  title="If you make your e-mail address public, it will be visible to other logged in users.">
+                            </span>
+                        </label>
                     </div>
+                </div>
 
-                    <hr>
-                    <div class="form-group">
-                        <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
-                        <div class="col-sm-3">
-                            <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
-                        </div>
-                        <div class="col-sm-offset-6 col-sm-6">
-                            <a href="#" onclick="reloadCaptcha()">Reload image</a>
-                        </div>
+                <hr>
+                <div class="form-group">
+                    <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
+                    <div class="col-sm-3">
+                        <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
                     </div>
-                    <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
-                        <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
-                        <div class="col-sm-9">
-                            <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
-                            <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
-                                   placeholder="Enter characters">
-                            {{ if .FieldErrors.captcha }}
-                            <span class="help-block">{{ .FieldErrors.captcha }}</span>
-                            {{ end }}
-                        </div>
+                    <div class="col-sm-offset-6 col-sm-6">
+                        <a href="#" onclick="reloadCaptcha()">Reload image</a>
                     </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
+                    <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
+                    <div class="col-sm-9">
+                        <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
+                        <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
+                               placeholder="Enter characters">
+                        {{ if .FieldErrors.captcha }}
+                        <span class="help-block">{{ .FieldErrors.captcha }}</span>
+                        {{ end }}
+                    </div>
+                </div>
 
-                    <hr>
-                    <div class="form-group">
-                        <div class="col-sm-9 col-sm-offset-3">
-                            <p>By clicking "Create account", you agree to our
-                                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
-                            </p>
-                            <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
-                            <button type="submit" class="btn btn-default">Create account</button>
-                        </div>
+                <hr>
+                <div class="form-group">
+                    <div class="col-sm-9 col-sm-offset-3">
+                        <p>By clicking "Create account", you agree to our
+                            <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
+                        </p>
+                        <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
+                        <button type="submit" class="btn btn-default">Create account</button>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-    <div class="step">
+
+    <div class="stepper">
         <div>
-            <div class="circle">2</div>
-            <div class="line"></div>
+            <div class="stp-circle">2</div>
+            <div class="stp-line"></div>
         </div>
         <div>
-            <div class="title stepoffset">Affiliation (Optional)</div>
-            <div class="content stepoffset">
-                <div id="step-2" class="panel-collapse collapse">
-                    <h4>User information</h4>
-                    <hr>
-                    <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
-                        <label for="reg-title" class="col-sm-3 control-label">Title</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-title" name="title"
-                                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
-                            {{ if .FieldErrors.title }}
-                            <span class="help-block">{{ .FieldErrors.title }}</span>
-                            {{ end }}
-                        </div>
+            <div class="stp-title stp-offset">Affiliation (Optional)</div>
+            <div class="stp-offset collapse">
+                <h4>User information</h4>
+                <hr>
+                <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
+                    <label for="reg-title" class="col-sm-3 control-label">Title</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-title" name="title"
+                               placeholder="Title" value="{{ .Title.String }}" maxlength="512">
+                        {{ if .FieldErrors.title }}
+                        <span class="help-block">{{ .FieldErrors.title }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
-                        <label for="reg-fn" class="col-sm-3 control-label">First name</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-fn" name="first_name"
-                                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
-                            {{ if .FieldErrors.first_name }}
-                            <span class="help-block">{{ .FieldErrors.first_name }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
+                    <label for="reg-fn" class="col-sm-3 control-label">First name</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-fn" name="first_name"
+                               placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
+                        {{ if .FieldErrors.first_name }}
+                        <span class="help-block">{{ .FieldErrors.first_name }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
-                        <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-mn" name="middle_name"
-                                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
-                            {{ if .FieldErrors.middle_name }}
-                            <span class="help-block">{{ .FieldErrors.middle_name }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
+                    <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-mn" name="middle_name"
+                               placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
+                        {{ if .FieldErrors.middle_name }}
+                        <span class="help-block">{{ .FieldErrors.middle_name }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
-                        <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-ln" name="last_name"
-                                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
-                            {{ if .FieldErrors.last_name }}
-                            <span class="help-block">{{ .FieldErrors.last_name }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
+                    <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-ln" name="last_name"
+                               placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
+                        {{ if .FieldErrors.last_name }}
+                        <span class="help-block">{{ .FieldErrors.last_name }}</span>
+                        {{ end }}
                     </div>
+                </div>
 
-                    <h4>Affiliation</h4>
-                    <hr>
-                    <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
-                        <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-institute" name="institute"
-                                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
-                            {{ if .FieldErrors.institute }}
-                            <span class="help-block">{{ .FieldErrors.institute }}</span>
-                            {{ end }}
-                        </div>
+                <h4>Affiliation</h4>
+                <hr>
+                <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
+                    <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-institute" name="institute"
+                               placeholder="Institute" value="{{ .Institute }}" maxlength="512">
+                        {{ if .FieldErrors.institute }}
+                        <span class="help-block">{{ .FieldErrors.institute }}</span>
+                        {{ end }}
                     </div>
+                </div>
 
-                    <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
-                        <label for="reg-department" class="col-sm-3 control-label">Department</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-department" name="department"
-                                   placeholder="Department" value="{{ .Department }}" maxlength="512">
-                            {{ if .FieldErrors.department }}
-                            <span class="help-block">{{ .FieldErrors.department }}</span>
-                            {{ end }}
-                        </div>
+                <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
+                    <label for="reg-department" class="col-sm-3 control-label">Department</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-department" name="department"
+                               placeholder="Department" value="{{ .Department }}" maxlength="512">
+                        {{ if .FieldErrors.department }}
+                        <span class="help-block">{{ .FieldErrors.department }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
-                        <label for="reg-city" class="col-sm-3 control-label">City</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-city" name="city"
-                                   placeholder="City" value="{{ .City }}" maxlength="512">
-                            {{ if .FieldErrors.city }}
-                            <span class="help-block">{{ .FieldErrors.city }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
+                    <label for="reg-city" class="col-sm-3 control-label">City</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-city" name="city"
+                               placeholder="City" value="{{ .City }}" maxlength="512">
+                        {{ if .FieldErrors.city }}
+                        <span class="help-block">{{ .FieldErrors.city }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
-                        <label for="reg-country" class="col-sm-3 control-label">Country</label>
-                        <div class="col-sm-9">
-                            <input type="text" class="form-control" id="reg-country" name="country"
-                                   placeholder="Country" value="{{ .Country }}" maxlength="512">
-                            {{ if .FieldErrors.country }}
-                            <span class="help-block">{{ .FieldErrors.country }}</span>
-                            {{ end }}
-                        </div>
+                </div>
+                <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
+                    <label for="reg-country" class="col-sm-3 control-label">Country</label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" id="reg-country" name="country"
+                               placeholder="Country" value="{{ .Country }}" maxlength="512">
+                        {{ if .FieldErrors.country }}
+                        <span class="help-block">{{ .FieldErrors.country }}</span>
+                        {{ end }}
                     </div>
-                    <div class="form-group">
-                        <div class="col-sm-offset-3 col-sm-9 checkbox">
-                            <label for="reg-affiliation-public">
-                                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
-                                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
-                                Make affiliation public
-                                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                                      title="If you make your affiliation public, it will be visible to other logged in users.">
-                                </span>
-                            </label>
-                        </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-9 checkbox">
+                        <label for="reg-affiliation-public">
+                            <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
+                                   value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
+                            Make affiliation public
+                            <span class="glyphicon glyphicon-info-sign c-blue-gnode" data-toggle="tooltip"
+                                  title="If you make your affiliation public, it will be visible to other logged in users.">
+                            </span>
+                        </label>
                     </div>
+                </div>
 
-                    <hr>
-                    <div class="form-group">
-                        <div class="col-sm-9 col-sm-offset-3">
-                            <p>By clicking "Create account", you agree to our
-                                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
-                            </p>
-                            <input type="button" class="btn btn-primary" value="Back" onclick="toggleStepper()">
-                            <button type="submit" class="btn btn-success">Create account</button>
-                        </div>
+                <hr>
+                <div class="form-group">
+                    <div class="col-sm-9 col-sm-offset-3">
+                        <p>By clicking "Create account", you agree to our
+                            <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
+                        </p>
+                        <input type="button" class="btn btn-primary" value="Back" onclick="toggleStepper()">
+                        <button type="submit" class="btn btn-success">Create account</button>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-    <br /><br />
-
-    <div class="line"></div>
 </form>
 
 <script type="text/javascript">
@@ -256,41 +250,6 @@
 <style type="text/css">
     .glyph-blue {
         color: rgb(85, 123, 185);
-    }
-    .step {
-        position: relative;
-        min-height: 50px;
-    }
-    // position all first child divs of a 'step' element horizontally at the same height
-    .step > div:first-child {
-        position: static;
-        height: 0;
-    }
-    // vertical offset of all
-    .stepoffset {
-        margin-left: 32px;
-        padding-left: 16px;
-    }
-    .circle {
-        background: rgb(85, 123, 185);
-        width: 32px;
-        height: 32px;
-        line-height: 32px;
-        border-radius: 16px;
-        position: relative;
-        color: white;
-        text-align: center;
-    }
-    .line {
-        position: absolute;
-        border-left: 1px solid rgb(85, 123, 185);
-        left: 16px;
-        bottom: 5px;
-        top: 35px;
-    }
-    .title {
-        line-height: 32px;
-        font-weight: bold;
     }
 </style>
 

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -92,9 +92,13 @@
                             {{ end }}
                         </div>
                     </div>
+
                     <hr>
                     <div class="form-group">
                         <div class="col-sm-9 col-sm-offset-3">
+                            <p>By clicking "Create account", you agree to our
+                                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
+                            </p>
                             <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
                             <button type="submit" class="btn btn-default">Create account</button>
                         </div>
@@ -217,13 +221,8 @@
                             <p>By clicking "Create account", you agree to our
                                 <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
                             </p>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <div class="col-sm-9 col-sm-offset-3">
                             <input type="button" class="btn btn-primary" value="Back" onclick="toggleStepper()">
-                            <button type="submit" class="btn btn-default">Create account</button>
+                            <button type="submit" class="btn btn-success">Create account</button>
                         </div>
                     </div>
                 </div>
@@ -232,10 +231,7 @@
     </div>
     <br /><br />
 
-    <div class="line">
-        <br><br><br><br><br><br>
-    </div>
-
+    <div class="line"></div>
 </form>
 
 <script type="text/javascript">

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -10,208 +10,232 @@
 {{ end }}
 
 <form action="/oauth/registration" method="post" class="form-horizontal">
+    <div class="step">
+        <div>
+            <div class="circle">1</div>
+            <div class="line"></div>
+        </div>
+        <div>
+            <div class="stepoffset title">Personal account</div>
+            <div class="stepoffset content">
+                <div id="step-1" class="collapse in">
+                    <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
+                        <label for="reg-login" class="col-sm-3 control-label">Login *</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-login" name="login"
+                                   placeholder="Login" value="{{ .Login }}" maxlength="512">
+                            {{ if .FieldErrors.login }}
+                            <span class="help-block">{{ .FieldErrors.login }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                        <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
+                        <div class="col-sm-9">
+                            <input type="password" class="form-control" id="reg-password-input"
+                                   name="password" placeholder="Password" maxlength="512">
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                        <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
+                        <div class="col-sm-9">
+                            <input type="password" class="form-control" id="reg-password-control"
+                                   name="password_control" placeholder="Password" maxlength="512">
+                            {{ if .FieldErrors.password }}
+                            <span class="help-block">{{ .FieldErrors.password }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
+                    <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
+                        <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-email" name="email"
+                                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
+                            {{ if .FieldErrors.email }}
+                            <span class="help-block">{{ .FieldErrors.email }}</span>
+                            {{ end }}
+                            <span class="help-block">Note: A valid e-mail address is required to activate your account.</span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-3 col-sm-9 checkbox">
+                            <label for="reg-email-public">
+                                <input type="checkbox" id="reg-email-public" name="is_email_public"
+                                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
+                                Make e-mail public
+                                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                                      title="If you make your e-mail address public, it will be visible to other logged in users.">
+                                </span>
+                            </label>
+                        </div>
+                    </div>
 
-    <div id="stepper">
-        <!-- first stepper page -->
-        <div id="step-1" class="collapse in">
-            <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
-                <label for="reg-login" class="col-sm-3 control-label">Login *</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-login" name="login"
-                           placeholder="Login" value="{{ .Login }}" maxlength="512">
-                    {{ if .FieldErrors.login }}
-                    <span class="help-block">{{ .FieldErrors.login }}</span>
-                    {{ end }}
+                    <hr>
+                    <div class="form-group">
+                        <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
+                        <div class="col-sm-3">
+                            <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
+                        </div>
+                        <div class="col-sm-offset-6 col-sm-6">
+                            <a href="#" onclick="reloadCaptcha()">Reload image</a>
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
+                        <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
+                        <div class="col-sm-9">
+                            <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
+                            <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
+                                   placeholder="Enter characters">
+                            {{ if .FieldErrors.captcha }}
+                            <span class="help-block">{{ .FieldErrors.captcha }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <hr>
+                    <div class="form-group">
+                        <div class="col-sm-9 col-sm-offset-3">
+                            <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
+                            <button type="submit" class="btn btn-default">Create account</button>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-                <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
-                <div class="col-sm-9">
-                    <input type="password" class="form-control" id="reg-password-input"
-                           name="password" placeholder="Password" maxlength="512">
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-                <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
-                <div class="col-sm-9">
-                    <input type="password" class="form-control" id="reg-password-control"
-                           name="password_control" placeholder="Password" maxlength="512">
-                    {{ if .FieldErrors.password }}
-                    <span class="help-block">{{ .FieldErrors.password }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
-            <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
-                <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-email" name="email"
-                           placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
-                    {{ if .FieldErrors.email }}
-                    <span class="help-block">{{ .FieldErrors.email }}</span>
-                    {{ end }}
-                    <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
-                </div>
-            </div>
-            <div class="form-group">
-                <div class="col-sm-offset-3 col-sm-9 checkbox">
-                    <label for="reg-email-public">
-                        <input type="checkbox" id="reg-email-public" name="is_email_public"
-                               value="true" {{ if .IsEmailPublic }} checked {{ end }}>
-                        Make e-mail public
-                        <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                              title="If you make your e-mail address public, it will be visible to other logged in users.">
-                    </span>
-                    </label>
-                </div>
-            </div>
-
-            <hr>
-            <div class="form-group">
-                <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
-                <div class="col-sm-3">
-                    <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
-                </div>
-                <div class="col-sm-offset-6 col-sm-6">
-                    <a href="#" onclick="reloadCaptcha()">Reload image</a>
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
-                <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
-                <div class="col-sm-9">
-                    <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
-                    <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
-                           placeholder="Enter characters">
-                    {{ if .FieldErrors.captcha }}
-                    <span class="help-block">{{ .FieldErrors.captcha }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <hr>
-            <div class="form-group">
-                <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
             </div>
         </div>
+    </div>
+    <div class="step">
+        <div>
+            <div class="circle">2</div>
+            <div class="line"></div>
+        </div>
+        <div>
+            <div class="title stepoffset">Affiliation (Optional)</div>
+            <div class="content stepoffset">
+                <div id="step-2" class="panel-collapse collapse">
+                    <h4>User information</h4>
+                    <hr>
+                    <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
+                        <label for="reg-title" class="col-sm-3 control-label">Title</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-title" name="title"
+                                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
+                            {{ if .FieldErrors.title }}
+                            <span class="help-block">{{ .FieldErrors.title }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
+                        <label for="reg-fn" class="col-sm-3 control-label">First name</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-fn" name="first_name"
+                                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
+                            {{ if .FieldErrors.first_name }}
+                            <span class="help-block">{{ .FieldErrors.first_name }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
+                        <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-mn" name="middle_name"
+                                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
+                            {{ if .FieldErrors.middle_name }}
+                            <span class="help-block">{{ .FieldErrors.middle_name }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
+                        <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-ln" name="last_name"
+                                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
+                            {{ if .FieldErrors.last_name }}
+                            <span class="help-block">{{ .FieldErrors.last_name }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
 
-        <!-- second stepper page -->
-        <div id="step-2" class="panel-collapse collapse">
-            <h4>User information</h4>
-            <hr>
-            <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
-                <label for="reg-title" class="col-sm-3 control-label">Title</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-title" name="title"
-                           placeholder="Title" value="{{ .Title.String }}" maxlength="512">
-                    {{ if .FieldErrors.title }}
-                    <span class="help-block">{{ .FieldErrors.title }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
-                <label for="reg-fn" class="col-sm-3 control-label">First name</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-fn" name="first_name"
-                           placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
-                    {{ if .FieldErrors.first_name }}
-                    <span class="help-block">{{ .FieldErrors.first_name }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
-                <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-mn" name="middle_name"
-                           placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
-                    {{ if .FieldErrors.middle_name }}
-                    <span class="help-block">{{ .FieldErrors.middle_name }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
-                <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-ln" name="last_name"
-                           placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
-                    {{ if .FieldErrors.last_name }}
-                    <span class="help-block">{{ .FieldErrors.last_name }}</span>
-                    {{ end }}
-                </div>
-            </div>
+                    <h4>Affiliation</h4>
+                    <hr>
+                    <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
+                        <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-institute" name="institute"
+                                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
+                            {{ if .FieldErrors.institute }}
+                            <span class="help-block">{{ .FieldErrors.institute }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
 
-            <h4>Affiliation</h4>
-            <hr>
-            <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
-                <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-institute" name="institute"
-                           placeholder="Institute" value="{{ .Institute }}" maxlength="512">
-                    {{ if .FieldErrors.institute }}
-                    <span class="help-block">{{ .FieldErrors.institute }}</span>
-                    {{ end }}
-                </div>
-            </div>
+                    <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
+                        <label for="reg-department" class="col-sm-3 control-label">Department</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-department" name="department"
+                                   placeholder="Department" value="{{ .Department }}" maxlength="512">
+                            {{ if .FieldErrors.department }}
+                            <span class="help-block">{{ .FieldErrors.department }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
+                        <label for="reg-city" class="col-sm-3 control-label">City</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-city" name="city"
+                                   placeholder="City" value="{{ .City }}" maxlength="512">
+                            {{ if .FieldErrors.city }}
+                            <span class="help-block">{{ .FieldErrors.city }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
+                        <label for="reg-country" class="col-sm-3 control-label">Country</label>
+                        <div class="col-sm-9">
+                            <input type="text" class="form-control" id="reg-country" name="country"
+                                   placeholder="Country" value="{{ .Country }}" maxlength="512">
+                            {{ if .FieldErrors.country }}
+                            <span class="help-block">{{ .FieldErrors.country }}</span>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-3 col-sm-9 checkbox">
+                            <label for="reg-affiliation-public">
+                                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
+                                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
+                                Make affiliation public
+                                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                                      title="If you make your affiliation public, it will be visible to other logged in users.">
+                                </span>
+                            </label>
+                        </div>
+                    </div>
 
-            <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
-                <label for="reg-department" class="col-sm-3 control-label">Department</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-department" name="department"
-                           placeholder="Department" value="{{ .Department }}" maxlength="512">
-                    {{ if .FieldErrors.department }}
-                    <span class="help-block">{{ .FieldErrors.department }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
-                <label for="reg-city" class="col-sm-3 control-label">City</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-city" name="city"
-                           placeholder="City" value="{{ .City }}" maxlength="512">
-                    {{ if .FieldErrors.city }}
-                    <span class="help-block">{{ .FieldErrors.city }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
-                <label for="reg-country" class="col-sm-3 control-label">Country</label>
-                <div class="col-sm-9">
-                    <input type="text" class="form-control" id="reg-country" name="country"
-                           placeholder="Country" value="{{ .Country }}" maxlength="512">
-                    {{ if .FieldErrors.country }}
-                    <span class="help-block">{{ .FieldErrors.country }}</span>
-                    {{ end }}
-                </div>
-            </div>
-            <div class="form-group">
-                <div class="col-sm-offset-3 col-sm-9 checkbox">
-                    <label for="reg-affiliation-public">
-                        <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
-                               value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
-                        Make affiliation public
-                        <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                              title="If you make your affiliation public, it will be visible to other logged in users.">
-                </span>
-                    </label>
-                </div>
-            </div>
+                    <hr>
+                    <div class="form-group">
+                        <div class="col-sm-9 col-sm-offset-3">
+                            <p>By clicking "Create account", you agree to our
+                                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
+                            </p>
+                        </div>
+                    </div>
 
-            <hr>
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3">
-                    <p>By clicking "Create account", you agree to our
-                        <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
-                    </p>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <div class="col-sm-9 col-sm-offset-3">
-                    <input type="button" class="btn btn-default" value="Back" onclick="toggleStepper()">
-                    <button type="submit" class="btn btn-default">Create account</button>
+                    <div class="form-group">
+                        <div class="col-sm-9 col-sm-offset-3">
+                            <input type="button" class="btn btn-primary" value="Back" onclick="toggleStepper()">
+                            <button type="submit" class="btn btn-default">Create account</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
     <br /><br />
+
+    <div class="line">
+        <br><br><br><br><br><br>
+    </div>
+
 </form>
 
 <script type="text/javascript">
@@ -236,6 +260,41 @@
 <style type="text/css">
     .glyph-blue {
         color: rgb(85, 123, 185);
+    }
+    .step {
+        position: relative;
+        min-height: 50px;
+    }
+    // position all first child divs of a 'step' element horizontally at the same height
+    .step > div:first-child {
+        position: static;
+        height: 0;
+    }
+    // vertical offset of all
+    .stepoffset {
+        margin-left: 32px;
+        padding-left: 16px;
+    }
+    .circle {
+        background: rgb(85, 123, 185);
+        width: 32px;
+        height: 32px;
+        line-height: 32px;
+        border-radius: 16px;
+        position: relative;
+        color: white;
+        text-align: center;
+    }
+    .line {
+        position: absolute;
+        border-left: 1px solid rgb(85, 123, 185);
+        left: 16px;
+        bottom: 5px;
+        top: 35px;
+    }
+    .title {
+        line-height: 32px;
+        font-weight: bold;
     }
 </style>
 

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -66,8 +66,8 @@
 
     <hr>
     <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9">Please verify that you are a person:</div>
-        <div class="col-sm-offset-3 col-sm-3">
+        <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
+        <div class="col-sm-3">
             <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
         </div>
         <div class="col-sm-offset-6 col-sm-6">

--- a/resources/templates/registration.html
+++ b/resources/templates/registration.html
@@ -11,192 +11,204 @@
 
 <form action="/oauth/registration" method="post" class="form-horizontal">
 
-    <h4>Account information</h4>
-    <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
-        <label for="reg-login" class="col-sm-3 control-label">Login *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-login" name="login"
-                   placeholder="Login" value="{{ .Login }}" maxlength="512">
-            {{ if .FieldErrors.login }}
-            <span class="help-block">{{ .FieldErrors.login }}</span>
-            {{ end }}
+    <div id="stepper">
+        <!-- first stepper page -->
+        <div id="step-1" class="collapse in">
+            <div class="form-group {{ if .FieldErrors.login }}has-error{{ end }}">
+                <label for="reg-login" class="col-sm-3 control-label">Login *</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-login" name="login"
+                           placeholder="Login" value="{{ .Login }}" maxlength="512">
+                    {{ if .FieldErrors.login }}
+                    <span class="help-block">{{ .FieldErrors.login }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
+                <div class="col-sm-9">
+                    <input type="password" class="form-control" id="reg-password-input"
+                           name="password" placeholder="Password" maxlength="512">
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
+                <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
+                <div class="col-sm-9">
+                    <input type="password" class="form-control" id="reg-password-control"
+                           name="password_control" placeholder="Password" maxlength="512">
+                    {{ if .FieldErrors.password }}
+                    <span class="help-block">{{ .FieldErrors.password }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
+            <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
+                <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-email" name="email"
+                           placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
+                    {{ if .FieldErrors.email }}
+                    <span class="help-block">{{ .FieldErrors.email }}</span>
+                    {{ end }}
+                    <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-9 checkbox">
+                    <label for="reg-email-public">
+                        <input type="checkbox" id="reg-email-public" name="is_email_public"
+                               value="true" {{ if .IsEmailPublic }} checked {{ end }}>
+                        Make e-mail public
+                        <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                              title="If you make your e-mail address public, it will be visible to other logged in users.">
+                    </span>
+                    </label>
+                </div>
+            </div>
+
+            <hr>
+            <div class="form-group">
+                <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
+                <div class="col-sm-3">
+                    <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
+                </div>
+                <div class="col-sm-offset-6 col-sm-6">
+                    <a href="#" onclick="reloadCaptcha()">Reload image</a>
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
+                <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
+                <div class="col-sm-9">
+                    <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
+                    <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
+                           placeholder="Enter characters">
+                    {{ if .FieldErrors.captcha }}
+                    <span class="help-block">{{ .FieldErrors.captcha }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <hr>
+            <div class="form-group">
+                <input type="button" class="btn btn-primary" value="Next" onclick="toggleStepper()">
+            </div>
         </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-        <label for="reg-password-input" class="col-sm-3 control-label">Password *</label>
-        <div class="col-sm-9">
-            <input type="password" class="form-control" id="reg-password-input"
-                   name="password" placeholder="Password" maxlength="512">
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.password }}has-error{{ end }}">
-        <label for="reg-password-control" class="col-sm-3 control-label">Re-enter password *</label>
-        <div class="col-sm-9">
-            <input type="password" class="form-control" id="reg-password-control"
-                   name="password_control" placeholder="Password" maxlength="512">
-            {{ if .FieldErrors.password }}
-            <span class="help-block">{{ .FieldErrors.password }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <input type="hidden" name="request_id" id="reg-request-id" value="{{ .RequestId }}">
-    <div class="form-group {{ if .FieldErrors.email }}has-error{{ end }}">
-        <label for="reg-email" class="col-sm-3 control-label">e-mail address *</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-email" name="email"
-                   placeholder="e-mail address" value="{{ .Email }}" maxlength="512">
-            {{ if .FieldErrors.email }}
-            <span class="help-block">{{ .FieldErrors.email }}</span>
-            {{ end }}
-            <span class="help-block">Note: A valid e-mail address is required to finish the registration process.</span>
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9 checkbox">
-            <label for="reg-email-public">
-                <input type="checkbox" id="reg-email-public" name="is_email_public"
-                       value="true" {{ if .IsEmailPublic }} checked {{ end }}>
-                Make e-mail public
-                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                      title="If you make your e-mail address public, it will be visible to other logged in users.">
+
+        <!-- second stepper page -->
+        <div id="step-2" class="panel-collapse collapse">
+            <h4>User information</h4>
+            <hr>
+            <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
+                <label for="reg-title" class="col-sm-3 control-label">Title</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-title" name="title"
+                           placeholder="Title" value="{{ .Title.String }}" maxlength="512">
+                    {{ if .FieldErrors.title }}
+                    <span class="help-block">{{ .FieldErrors.title }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
+                <label for="reg-fn" class="col-sm-3 control-label">First name</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-fn" name="first_name"
+                           placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
+                    {{ if .FieldErrors.first_name }}
+                    <span class="help-block">{{ .FieldErrors.first_name }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
+                <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-mn" name="middle_name"
+                           placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
+                    {{ if .FieldErrors.middle_name }}
+                    <span class="help-block">{{ .FieldErrors.middle_name }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
+                <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-ln" name="last_name"
+                           placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
+                    {{ if .FieldErrors.last_name }}
+                    <span class="help-block">{{ .FieldErrors.last_name }}</span>
+                    {{ end }}
+                </div>
+            </div>
+
+            <h4>Affiliation</h4>
+            <hr>
+            <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
+                <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-institute" name="institute"
+                           placeholder="Institute" value="{{ .Institute }}" maxlength="512">
+                    {{ if .FieldErrors.institute }}
+                    <span class="help-block">{{ .FieldErrors.institute }}</span>
+                    {{ end }}
+                </div>
+            </div>
+
+            <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
+                <label for="reg-department" class="col-sm-3 control-label">Department</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-department" name="department"
+                           placeholder="Department" value="{{ .Department }}" maxlength="512">
+                    {{ if .FieldErrors.department }}
+                    <span class="help-block">{{ .FieldErrors.department }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
+                <label for="reg-city" class="col-sm-3 control-label">City</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-city" name="city"
+                           placeholder="City" value="{{ .City }}" maxlength="512">
+                    {{ if .FieldErrors.city }}
+                    <span class="help-block">{{ .FieldErrors.city }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
+                <label for="reg-country" class="col-sm-3 control-label">Country</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="reg-country" name="country"
+                           placeholder="Country" value="{{ .Country }}" maxlength="512">
+                    {{ if .FieldErrors.country }}
+                    <span class="help-block">{{ .FieldErrors.country }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-9 checkbox">
+                    <label for="reg-affiliation-public">
+                        <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
+                               value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
+                        Make affiliation public
+                        <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
+                              title="If you make your affiliation public, it will be visible to other logged in users.">
                 </span>
-            </label>
-        </div>
-    </div>
+                    </label>
+                </div>
+            </div>
 
-    <hr>
-    <div class="form-group">
-        <label for="reg-image" class="col-sm-3 control-label">Please verify that you are a person</label>
-        <div class="col-sm-3">
-            <img id="reg-image" src="/captcha/{{ .CaptchaId }}.png" alt="Captcha image">
-        </div>
-        <div class="col-sm-offset-6 col-sm-6">
-            <a href="#" onclick="reloadCaptcha()">Reload image</a>
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.captcha}}has-error{{ end }}">
-        <label for="reg-captcha-resolve" class="col-sm-3 control-label">Enter displayed characters *</label>
-        <div class="col-sm-9">
-            <input type="hidden" name="captcha_id" id="reg-captcha-id" value="{{ .CaptchaId }}">
-            <input class="form-control" name="captcha_resolve" id="reg-captcha-resolve"
-                   placeholder="Enter characters">
-            {{ if .FieldErrors.captcha }}
-            <span class="help-block">{{ .FieldErrors.captcha }}</span>
-            {{ end }}
-        </div>
-    </div>
+            <hr>
+            <div class="form-group">
+                <div class="col-sm-9 col-sm-offset-3">
+                    <p>By clicking "Create account", you agree to our
+                        <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
+                    </p>
+                </div>
+            </div>
 
-    <h4>User information</h4>
-    <hr>
-    <div class="form-group {{ if .FieldErrors.title }}has-error{{ end }}">
-        <label for="reg-title" class="col-sm-3 control-label">Title</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-title" name="title"
-                   placeholder="Title" value="{{ .Title.String }}" maxlength="512">
-            {{ if .FieldErrors.title }}
-                <span class="help-block">{{ .FieldErrors.title }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.first_name }}has-error{{ end }}">
-        <label for="reg-fn" class="col-sm-3 control-label">First name</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-fn" name="first_name"
-                   placeholder="First Name" value="{{ .FirstName }}" maxlength="512">
-            {{ if .FieldErrors.first_name }}
-                <span class="help-block">{{ .FieldErrors.first_name }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.middle_name }}has-error{{ end }}">
-        <label for="reg-mn" class="col-sm-3 control-label">Middle name</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-mn" name="middle_name"
-                   placeholder="Middle Name" value="{{ .MiddleName.String }}" maxlength="512">
-            {{ if .FieldErrors.middle_name }}
-                <span class="help-block">{{ .FieldErrors.middle_name }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.last_name }}has-error{{ end }}">
-        <label for="reg-ln" class="col-sm-3 control-label">Last name</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-ln" name="last_name"
-                   placeholder="Last Name" value="{{ .LastName }}" maxlength="512">
-            {{ if .FieldErrors.last_name }}
-                <span class="help-block">{{ .FieldErrors.last_name }}</span>
-            {{ end }}
-        </div>
-    </div>
-
-    <h4>Affiliation</h4>
-    <hr>
-    <div class="form-group {{ if .FieldErrors.institute }}has-error{{ end }}">
-        <label for="reg-institute" class="col-sm-3 control-label">Institution</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-institute" name="institute"
-                   placeholder="Institute" value="{{ .Institute }}" maxlength="512">
-            {{ if .FieldErrors.institute }}
-                <span class="help-block">{{ .FieldErrors.institute }}</span>
-            {{ end }}
-        </div>
-    </div>
-
-    <div class="form-group {{ if .FieldErrors.department }}has-error{{ end }}">
-        <label for="reg-department" class="col-sm-3 control-label">Department</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-department" name="department"
-                   placeholder="Department" value="{{ .Department }}" maxlength="512">
-            {{ if .FieldErrors.department }}
-                <span class="help-block">{{ .FieldErrors.department }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.city }}has-error{{ end }}">
-        <label for="reg-city" class="col-sm-3 control-label">City</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-city" name="city"
-                   placeholder="City" value="{{ .City }}" maxlength="512">
-            {{ if .FieldErrors.city }}
-                <span class="help-block">{{ .FieldErrors.city }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group {{ if .FieldErrors.country }}has-error{{ end }}">
-        <label for="reg-country" class="col-sm-3 control-label">Country</label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" id="reg-country" name="country"
-                   placeholder="Country" value="{{ .Country }}" maxlength="512">
-            {{ if .FieldErrors.country }}
-                <span class="help-block">{{ .FieldErrors.country }}</span>
-            {{ end }}
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-9 checkbox">
-            <label for="reg-affiliation-public">
-                <input type="checkbox" id="reg-affiliation-public" name="is_affiliation_public"
-                       value="true" {{ if .IsAffiliationPublic }} checked {{ end }}>
-                Make affiliation public
-                <span class="glyphicon glyphicon-info-sign glyph-blue" data-toggle="tooltip"
-                      title="If you make your affiliation public, it will be visible to other logged in users.">
-                </span>
-            </label>
-        </div>
-    </div>
-
-    <hr>
-    <div class="form-group">
-        <div class="col-sm-9 col-sm-offset-3">
-            <p>By clicking "Create account", you agree to our
-                <a href="http://www.g-node.org/gin_terms">Terms of Use</a>.
-            </p>
-        </div>
-    </div>
-
-    <div class="form-group">
-        <div class="col-sm-9 col-sm-offset-3">
-            <button type="submit" class="btn btn-default">Create account</button>
+            <div class="form-group">
+                <div class="col-sm-9 col-sm-offset-3">
+                    <input type="button" class="btn btn-default" value="Back" onclick="toggleStepper()">
+                    <button type="submit" class="btn btn-default">Create account</button>
+                </div>
+            </div>
         </div>
     </div>
     <br /><br />
@@ -215,6 +227,10 @@
     $(document).ready(function() {
         $('[data-toggle="tooltip"]').tooltip();
     })
+
+    function toggleStepper() {
+        $('.collapse').toggle()
+    }
 </script>
 
 <style type="text/css">


### PR DESCRIPTION
This pull request refactors the account registration page to lower the threshold for people to actually register.
- Removes the required status of account fields "first name", "last name", "institution", "department", "city" and "country".
- Splits the registration form into a two page process, the first one is required, the second is optional. The first page contains all required fields, the second page contains all optional fields. An account can already be created when the first page has been completed.
- Uses a custom `stepper` component to visually underline the two step process with the optional second part.